### PR TITLE
Loop over included DBs for initialization if available

### DIFF
--- a/DatabaseInitializerFromAzBlob.cs
+++ b/DatabaseInitializerFromAzBlob.cs
@@ -21,12 +21,22 @@ namespace LogShippingService
             var dbRoot = Config.FullBackupPathTemplate[..Config.FullBackupPathTemplate.IndexOf(Config.DatabaseToken, StringComparison.OrdinalIgnoreCase)];
             Log.Debug("Az DB Path : {path}", dbRoot);
 
-            var folders = GetFoldersForAzBlob(dbRoot);
-            Log.Debug("Folders: {count}", folders.Count);
-            Parallel.ForEach(folders,
-                new ParallelOptions() { MaxDegreeOfParallelism = Config.MaxThreads },
-                ProcessDB
-            );
+            if (Config.IncludedDatabases.Count > 0)
+            {
+                Parallel.ForEach(Config.IncludedDatabases,
+                    new ParallelOptions() { MaxDegreeOfParallelism = Config.MaxThreads },
+                    ProcessDB
+                );
+            }
+            else
+            {
+                var folders = GetFoldersForAzBlob(dbRoot);
+                Log.Debug("Folders: {count}", folders.Count);
+                Parallel.ForEach(folders,
+                    new ParallelOptions() { MaxDegreeOfParallelism = Config.MaxThreads },
+                    ProcessDB
+                );
+            }
         }
         
         protected override void DoProcessDB(string db)


### PR DESCRIPTION
Loop over included database list if specified instead of trying to get a list of DBs by enumerating folders.   This is the easier and more reliable option if it's available.  It would work with paths like this where we have an AG folder per DB (e.g. basic availability groups)
\\SERVER\BACKUPS\FULL\{DatabaseName}_AG\{DatabaseName}

Fix order by for disk based initialization.