### PR TITLE
Fix kill connections

### DIFF
--- a/LogShipping.cs
+++ b/LogShipping.cs
@@ -319,9 +319,9 @@ namespace LogShippingService
             if (Config.KillUserConnections)
             {
                 var sql = $"IF DATABASEPROPERTYEX({db.SqlSingleQuote()},'IsInStandBy')=1\n";
-                sql += "BEGIN";
-                sql += $"\tALTER DATABASE {db.SqlQuote()} SET SINGLE_USER WITH ROLLBACK AFTER {Config.KillUserConnectionsWithRollBackAfter}";
-                sql += "END";
+                sql += "BEGIN\n";
+                sql += $"\tALTER DATABASE {db.SqlQuote()} SET SINGLE_USER WITH ROLLBACK AFTER {Config.KillUserConnectionsWithRollBackAfter}\n";
+                sql += "END\n";
                 Log.Warning("User connections to {db} are preventing restore operations.  Sessions will be killed after {seconds}. {sql}", db, Config.KillUserConnectionsWithRollBackAfter, sql);
                 try
                 {


### PR DESCRIPTION
We need some whitespace between {Config.KillUserConnectionsWithRollBackAfter} and END