### PR TITLE
Config File Path

### DIFF
--- a/sql-log-shipping-service/Config.cs
+++ b/sql-log-shipping-service/Config.cs
@@ -5,6 +5,7 @@ using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using Serilog;
 using System.ComponentModel.DataAnnotations;
+using System.Drawing.Drawing2D;
 using System.Globalization;
 using System.Runtime.CompilerServices;
 using System.Text;
@@ -34,8 +35,8 @@ namespace LogShippingService
         [JsonIgnore]
         public const string DatabaseToken = "{DatabaseName}";
 
-        /// <summary>Config file name</summary>
-        public const string ConfigFile = "appsettings.json";
+        /// <summary>Config file path</summary>
+        public static string ConfigFile => System.IO.Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "appsettings.json");
 
         #endregion "Constants"
 

--- a/sql-log-shipping-service/Program.cs
+++ b/sql-log-shipping-service/Program.cs
@@ -15,14 +15,13 @@ namespace LogShippingService
 {
     internal class Program
     {
-        public const string ConfigFile = "appsettings.json";
-        public static readonly NamedLocker Locker = new();
+       public static readonly NamedLocker Locker = new();
 
         private static void Main(string[] args)
         {
-            if (!File.Exists(ConfigFile))
+            if (!File.Exists(Config.ConfigFile))
             {
-                File.WriteAllText(ConfigFile, "{}");
+                File.WriteAllText(Config.ConfigFile, "{}");
             }
             Log.Logger = new LoggerConfiguration()
                 .WriteTo.Console()


### PR DESCRIPTION
Ensure config file is referenced from application folder instead of current directory.  This allows the app to be run from a different current directory. #53