### PR TITLE
Database should be returned to standby mode

### DIFF
--- a/sql-log-shipping-service/LogShipping.cs
+++ b/sql-log-shipping-service/LogShipping.cs
@@ -244,16 +244,19 @@ namespace LogShippingService
             {
                 if (DateTime.Now > maxTime)
                 {
+                    RestoreWithStandby(db); // Return database to standby mode
                     // Stop processing logs if max processing time is exceeded. Prevents a single DatabaseName that has fallen behind from impacting other DBs
                     throw new TimeoutException("Max processing time exceeded");
                 }
                 if (stoppingToken.IsCancellationRequested)
                 {
+                    RestoreWithStandby(db); // Return database to standby mode
                     Log.Information("Halt log restores for {db} due to stop request", db);
                     break;
                 }
                 if (!Waiter.CanRestoreLogsNow)
                 {
+                    RestoreWithStandby(db); // Return database to standby mode
                     Log.Information("Halt log restores for {db} due to Hours configuration", db);
                     break;
                 }


### PR DESCRIPTION
Databases should be returned to standby mode if processing is stopped due to max runtime exceeded, cancellation requested or configured runtime hours.
Error handling improvements