### PR TITLE
Restore with a different name

### DIFF
--- a/.github/workflows/build copy.yml
+++ b/.github/workflows/build copy.yml
@@ -1,0 +1,92 @@
+name: SQL Log Shipping Service - Restore Copy
+
+on: 
+    push:
+    workflow_dispatch:
+
+jobs:
+  build:
+    name: Build & Test
+    runs-on: windows-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: 8.0.x
+
+      - name: Build solution
+        run: dotnet build sql-log-shipping-service\LogShippingService.csproj -p:Configuration=Release -o Build
+
+      - name: Install SQL
+        uses: potatoqualitee/mssqlsuite@v1.7
+        with:
+          install: sqlengine
+          collation: Latin1_General_BIN
+
+      - name: Check SQL Install
+        run: | 
+          sqlcmd -S localhost -U sa -P dbatools.I0 -d tempdb -Q "SELECT @@version as Version;"
+          sqlcmd -S localhost -U sa -P dbatools.I0 -d tempdb -Q "SELECT SERVERPROPERTY('Collation') AS Collation;"
+
+      - name: DBATools
+        run: | 
+          Install-Module dbatools -Force
+          Set-DbatoolsConfig -FullName sql.connection.trustcert -Value $true -Register
+
+      - name: Create Database
+        run: |
+          New-DbaDatabase -SqlInstance localhost -Name LogShipping1,LogShipping2,LogShipping3 -RecoveryModel FULL
+          Get-DbaDatabase -SqlInstance localhost -ExcludeSystem | Select-Object {$_.Name}
+          # Test striped backup
+          Backup-DbaDatabase -SqlInstance localhost -Path C:\backup\FULL1\,C:\backup\FULL2\ -Database LogShipping1,LogShipping2,LogShipping3 -Type Full -CreateFolder
+          # Alternating log folders
+          Backup-DbaDatabase -SqlInstance localhost -Path C:\backup\LOG1\ -Database LogShipping2,LogShipping3 -Type LOG -CreateFolder
+          Backup-DbaDatabase -SqlInstance localhost -Path C:\backup\LOG2\ -Database LogShipping2,LogShipping3 -Type LOG -CreateFolder
+          Backup-DbaDatabase -SqlInstance localhost -Path C:\backup\LOG1\ -Database LogShipping1 -Type LOG -CreateFolder -FilePath LogShipping1_1.trn
+          Backup-DbaDatabase -SqlInstance localhost -Path C:\backup\LOG1\ -Database LogShipping1 -Type LOG -CreateFolder -FilePath LogShipping1_1.trn
+          Backup-DbaDatabase -SqlInstance localhost -Path C:\backup\LOG2\ -Database LogShipping1 -Type LOG -CreateFolder -FilePath LogShipping1_2.trn
+          Backup-DbaDatabase -SqlInstance localhost -Path C:\backup\LOG1\ -Database LogShipping1 -Type LOG -CreateFolder -FilePath LogShipping1_3.trn
+          Get-DbaDatabase -SqlInstance localhost -ExcludeSystem | Select-Object {$_.Name}
+          
+      - name: Deploy App
+        run: | 
+          New-Item -Path C:\sql-log-shipping-service -ItemType Directory
+          New-Item -Path C:\Standby -ItemType Directory
+          Copy-Item -Path .\Build\* -Destination C:\sql-log-shipping-service -Recurse
+      
+      - name: Configure 1
+        shell: cmd
+        run: | 
+          "C:\sql-log-shipping-service\LogShippingService.exe" --Destination "Data Source=LOCALHOST;Integrated Security=True;Encrypt=True;Trust Server Certificate=True" --LogFilePath "C:\Backup\LOG1\{DatabaseName},C:\Backup\LOG2\{DatabaseName}" --FullFilePath "C:\Backup\FULL1\{DatabaseName},C:\Backup\FULL2\{DatabaseName}" --StandbyFileName "C:\Standby\{DatabaseName}_Standby.BAK" --RestoreDatabaseNameSuffix "_Copy"
+    
+      - name: Run service
+        run: | 
+          sc.exe create "LogShippingService" binpath="C:\sql-log-shipping-service\LogShippingService.exe"
+          net start LogShippingService
+
+      - name: Wait & Output Logs
+        run: | 
+            $LoopCount=0
+            $MaxLoopCount=30
+            while((Get-DbaDatabase -SqlInstance "LOCALHOST" -Status "Standby").Count -lt 3 -and $LoopCount -lt $MaxLoopCount) {
+              Start-Sleep -s 2
+              Write-Output "Waiting for databases to be in Standby mode"
+              $LoopCount++
+            }
+            if($LoopCount -eq $MaxLoopCount) {
+              Write-Warning "Timeout waiting for databases to be in Standby mode"
+            }
+            Get-ChildItem -Path C:\sql-log-shipping-service\Logs | Get-Content
+
+      - name: Run Pester Tests for Restore Copy
+        run: |     
+          Install-Module Pester -Force -SkipPublisherCheck
+          Import-Module Pester -PassThru
+          Invoke-Pester -Output Detailed test\CI_Workflow-Restore-Copy.Tests.ps1
+
+      - name: Unit Test
+        run: dotnet test sql-log-shipping-service-tests\LogShippingServiceTests.csproj --verbosity normal

--- a/sql-log-shipping-service/CommandLineOptions.cs
+++ b/sql-log-shipping-service/CommandLineOptions.cs
@@ -126,5 +126,11 @@ namespace LogShippingService
 
         [Option("RestoreDatabaseNameSuffix", Required = false, HelpText = "Change the name of the database on the destination by adding a suffix")]
         public string? RestoreDatabaseNameSuffix { get; set; }
+
+        [Option("OldName", Required = false, HelpText = "Option to restore a database with a new name. e.g. --OldName OriginalName --NewName DestinationName.  Omit --NewName to remove a mapping. Repeat as required for multiple databases. Has priority over RestoreDatabaseNamePrefix/RestoreDatabaseNameSuffix")]
+        public string? OldName { get; set; }
+
+        [Option("NewName", Required = false, HelpText = "Option to restore a database with a new name. e.g. --OldName OriginalName --NewName DestinationName.  Omit --NewName to remove a mapping. Repeat as required for multiple databases. Has priority over RestoreDatabaseNamePrefix/RestoreDatabaseNameSuffix")]
+        public string? NewName { get; set; }
     }
 }

--- a/sql-log-shipping-service/CommandLineOptions.cs
+++ b/sql-log-shipping-service/CommandLineOptions.cs
@@ -120,5 +120,11 @@ namespace LogShippingService
 
         [Option("Run", Required = false, HelpText = "Run without saving changes to the config")]
         public bool Run { get; set; }
+
+        [Option("RestoreDatabaseNamePrefix", Required = false, HelpText = "Change the name of the database on the destination by adding a prefix")]
+        public string? RestoreDatabaseNamePrefix { get; set; }
+
+        [Option("RestoreDatabaseNameSuffix", Required = false, HelpText = "Change the name of the database on the destination by adding a suffix")]
+        public string? RestoreDatabaseNameSuffix { get; set; }
     }
 }

--- a/sql-log-shipping-service/Config.cs
+++ b/sql-log-shipping-service/Config.cs
@@ -396,6 +396,12 @@ namespace LogShippingService
         [JsonProperty(DefaultValueHandling = DefaultValueHandling.Ignore)]
         public string? MSDBPathReplace { get; set; }
 
+        [JsonProperty(DefaultValueHandling = DefaultValueHandling.Ignore)]
+        public string? RestoreDatabaseNamePrefix { get; set; }
+
+        [JsonProperty(DefaultValueHandling = DefaultValueHandling.Ignore)]
+        public string? RestoreDatabaseNameSuffix { get; set; }
+
         #endregion Initialization
 
         #region OtherOptions
@@ -720,6 +726,16 @@ namespace LogShippingService
                             if (opts.SecretKey != null)
                             {
                                 SecretKey = opts.SecretKey;
+                            }
+
+                            if (opts.RestoreDatabaseNamePrefix != null)
+                            {
+                                RestoreDatabaseNamePrefix = opts.RestoreDatabaseNamePrefix;
+                            }
+
+                            if (opts.RestoreDatabaseNameSuffix != null)
+                            {
+                                RestoreDatabaseNameSuffix = opts.RestoreDatabaseNameSuffix;
                             }
                             run = opts.Run;
                         }

--- a/sql-log-shipping-service/DatabaseInitializerBase.cs
+++ b/sql-log-shipping-service/DatabaseInitializerBase.cs
@@ -224,11 +224,19 @@ namespace LogShippingService
 
         public static string GetDestinationDatabaseName(string sourceDB)
         {
+            if (Config.SourceToDestinationMapping.TryGetValue(sourceDB.ToLower(), out var targetDB))
+            {
+                return targetDB;
+            }
             return Config.RestoreDatabaseNamePrefix + sourceDB + Config.RestoreDatabaseNameSuffix;
         }
 
         public static string GetSourceDatabaseName(string destinationDB)
         {
+            if (Config.DestinationToSourceMapping.TryGetValue(destinationDB.ToLower(), out var _sourceDB))
+            {
+                return _sourceDB;
+            }
             var prefix = Config.RestoreDatabaseNamePrefix ?? string.Empty;
             var suffix = Config.RestoreDatabaseNameSuffix ?? string.Empty;
 

--- a/sql-log-shipping-service/ExtensionMethods.cs
+++ b/sql-log-shipping-service/ExtensionMethods.cs
@@ -41,5 +41,10 @@
         {
             return backupFiles.Select(f => f.FilePath).ToList();
         }
+
+        public static string RemoveInvalidFileNameChars(this string filename)
+        {
+            return string.Concat(filename.Split(Path.GetInvalidFileNameChars()));
+        }
     }
 }

--- a/sql-log-shipping-service/LastBackup.cs
+++ b/sql-log-shipping-service/LastBackup.cs
@@ -37,17 +37,18 @@ namespace LogShippingService
             }
         }
 
-        public void Restore()
+        public void Restore(string? targetDb = null)
         {
+            targetDb ??= DatabaseName;
             Dictionary<string, string>? moves = null;
             if (BackupType == BackupHeader.BackupTypes.DatabaseFull)
             {
                 moves = DataHelper.GetFileMoves(FileList, DeviceType, Config.Destination,
                     Config.MoveDataFolder,
-                    Config.MoveLogFolder, Config.MoveFileStreamFolder);
+                    Config.MoveLogFolder, Config.MoveFileStreamFolder, DatabaseName, targetDb);
             }
 
-            var sql = GetRestoreDbScript(moves);
+            var sql = GetRestoreDbScript(moves, targetDb);
             DataHelper.ExecuteWithTiming(sql, Config.Destination);
         }
 
@@ -83,7 +84,7 @@ namespace LogShippingService
 
         public string GetFileListOnlyScript() => DataHelper.GetFileListOnlyScript(FileList, DeviceType);
 
-        public string GetRestoreDbScript(Dictionary<string, string>? moves) => DataHelper.GetRestoreDbScript(FileList, DatabaseName, DeviceType, BackupType == BackupHeader.BackupTypes.DatabaseFull, moves);
+        public string GetRestoreDbScript(Dictionary<string, string>? moves, string targetDb) => DataHelper.GetRestoreDbScript(FileList, targetDb, DeviceType, BackupType == BackupHeader.BackupTypes.DatabaseFull, moves);
 
         internal static DataTable GetFilesForLastBackup(string db, char backupType, string connectionString)
         {

--- a/test/CI_Workflow-Restore-Copy.Tests.ps1
+++ b/test/CI_Workflow-Restore-Copy.Tests.ps1
@@ -1,0 +1,25 @@
+Describe 'CI Workflow checks - Restore Copy' {
+
+    It 'Test Standby Count' {
+        # Expect 3 DBs to be in standby state
+         @(Get-DbaDatabase -SqlInstance "LOCALHOST" -Status "Standby").Count | Should -Be 3
+    }
+    It 'Test Normal Count' {
+        # Expect 3 DBs to be in normal state - we are restoring a copy of these databases
+         @(Get-DbaDatabase -SqlInstance "LOCALHOST" -Status "Normal" -Database "LogShipping1","LogShipping2","LogShipping3").Count | Should -Be 3
+    }
+    It '2 logical backups in same physical file check' {
+        # LogShipping1_2.trn as 2 logical backups.  If LogShipping1_3.trn is restored, then we handled it OK
+         $results= Invoke-DbaQuery -SqlInstance "LOCALHOST" -As PSObject -Query "SELECT TOP(1) bmf.physical_device_name AS LastLogFile
+         FROM msdb.dbo.restorehistory rsh
+         INNER JOIN msdb.dbo.backupset bs ON rsh.backup_set_id = bs.backup_set_id
+         INNER JOIN msdb.dbo.restorefile rf ON rsh.restore_history_id = rf.restore_history_id
+         INNER JOIN msdb.dbo.backupmediafamily bmf ON bmf.media_set_id = bs.media_set_id
+         WHERE rsh.restore_type = 'L'
+         AND rsh.destination_database_name='LogShipping1_Copy'
+         ORDER BY rsh.restore_history_id DESC;"
+
+         $results.LastLogFile | Should -Be "C:\Backup\LOG1\LogShipping1\LogShipping1_3.trn"        
+    }
+
+}


### PR DESCRIPTION
Add support for restoring databases with a different name by adding a prefix or suffix to the original database name.
Add support for restoring databases with a different name with an explicit mapping.
Update workflows