### PR TITLE
Database re-initialization option

### DIFF
--- a/.github/workflows/build-reinitialize.yml
+++ b/.github/workflows/build-reinitialize.yml
@@ -1,0 +1,352 @@
+name: SQL Log Shipping Service - Re-initialize
+
+on:
+    push:
+    workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: reinitialize-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    name: Build & Test Re-initialize
+    runs-on: windows-latest
+    defaults:
+      run:
+        shell: pwsh
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7
+
+      - name: Setup
+        uses: actions/setup-dotnet@v5
+        with:
+          dotnet-version: 10.0.x
+
+      - name: Build solution
+        run: dotnet build sql-log-shipping-service\LogShippingService.csproj -p:Configuration=Release -o Build
+
+      - name: Install SQL
+        uses: potatoqualitee/mssqlsuite@v1.12
+        with:
+          install: sqlengine
+          collation: Latin1_General_BIN
+
+      - name: Check SQL Install
+        run: |
+          sqlcmd -S localhost -U sa -P dbatools.I0 -d tempdb -Q "SELECT @@version as Version;"
+          sqlcmd -S localhost -U sa -P dbatools.I0 -d tempdb -Q "SELECT SERVERPROPERTY('Collation') AS Collation;"
+
+      - name: DBATools
+        run: |
+          Install-Module dbatools -Force
+          Set-DbatoolsConfig -FullName sql.connection.trustcert -Value $true -Register
+
+      - name: Create Databases (initial state)
+        run: |
+          # ReInit1 - source will be dropped & re-created (new incarnation)
+          # ReInit2 - source recovery model will be switched to SIMPLE and back to FULL (broken log chain)
+          # ReInit3 - source continues normally and must NOT be re-initialized
+          # Source databases stay online.  A copy of each is log shipped using the _Copy suffix.
+          New-DbaDatabase -SqlInstance localhost -Name ReInit1,ReInit2,ReInit3 -RecoveryModel FULL
+          foreach($db in 'ReInit1','ReInit2','ReInit3') {
+            Invoke-DbaQuery -SqlInstance localhost -Database $db -Query "CREATE TABLE dbo.Marker(Id INT NOT NULL); INSERT INTO dbo.Marker(Id) VALUES(1);"
+          }
+          Backup-DbaDatabase -SqlInstance localhost -Path C:\backup\FULL\ -Database ReInit1,ReInit2,ReInit3 -Type Full -CreateFolder -TimeStampFormat yyyyMMddHHmmss
+          Backup-DbaDatabase -SqlInstance localhost -Path C:\backup\LOG\ -Database ReInit1,ReInit2,ReInit3 -Type LOG -CreateFolder -TimeStampFormat yyyyMMddHHmmss
+          Get-DbaDatabase -SqlInstance localhost -ExcludeSystem | Select-Object {$_.Name}
+
+      - name: Deploy App
+        run: |
+          New-Item -Path C:\sql-log-shipping-service -ItemType Directory
+          New-Item -Path C:\Standby -ItemType Directory
+          Copy-Item -Path .\Build\* -Destination C:\sql-log-shipping-service -Recurse
+
+      - name: Configure
+        shell: cmd
+        run: |
+          "C:\sql-log-shipping-service\LogShippingService.exe" --Destination "Data Source=LOCALHOST;Integrated Security=True;Encrypt=True;Trust Server Certificate=True" --LogFilePath "C:\Backup\LOG\{DatabaseName}" --FullFilePath "C:\Backup\FULL\{DatabaseName}" --StandbyFileName "C:\Standby\{DatabaseName}_Standby.BAK" --RestoreDatabaseNameSuffix "_Copy" --EnableReinitialization true --DelayBetweenIterationsMs 5000
+
+      - name: Run service
+        run: |
+          sc.exe create "LogShippingService" binpath="C:\sql-log-shipping-service\LogShippingService.exe"
+          net start LogShippingService
+
+      - name: Wait for initial standby
+        run: |
+          $targets = 'ReInit1_Copy','ReInit2_Copy','ReInit3_Copy'
+          $LoopCount=0; $MaxLoopCount=60; $ready=$false
+          while(-not $ready -and $LoopCount -lt $MaxLoopCount) {
+            Start-Sleep -s 2; $LoopCount++
+            $ok=0
+            foreach($t in $targets) {
+              try {
+                if(Get-DbaDatabase -SqlInstance localhost -Database $t -Status Standby) {
+                  $res = Invoke-DbaQuery -SqlInstance localhost -Database $t -As PSObject -Query "SELECT MAX(Id) AS Id FROM dbo.Marker"
+                  if($res.Id -eq 1) { $ok++ }
+                }
+              } catch { }
+            }
+            if($ok -eq $targets.Count) { $ready=$true }
+            Write-Output "Waiting for initial standby ($ok/$($targets.Count))..."
+          }
+          if(-not $ready) {
+            Get-ChildItem -Path C:\sql-log-shipping-service\Logs | Get-Content
+            throw "Timeout waiting for initial standby"
+          }
+          Write-Output "All copies initialized (marker = 1)."
+
+      - name: Apply scenarios
+        run: |
+          # ReInit1: drop & re-create the source with the same name - a new database incarnation
+          Remove-DbaDatabase -SqlInstance localhost -Database ReInit1 -Confirm:$false
+          New-DbaDatabase -SqlInstance localhost -Name ReInit1 -RecoveryModel FULL
+          Invoke-DbaQuery -SqlInstance localhost -Database ReInit1 -Query "CREATE TABLE dbo.Marker(Id INT NOT NULL); INSERT INTO dbo.Marker(Id) VALUES(2);"
+          Backup-DbaDatabase -SqlInstance localhost -Path C:\backup\FULL\ -Database ReInit1 -Type Full -CreateFolder -TimeStampFormat yyyyMMddHHmmss
+          Backup-DbaDatabase -SqlInstance localhost -Path C:\backup\LOG\ -Database ReInit1 -Type LOG -CreateFolder -TimeStampFormat yyyyMMddHHmmss
+
+          # ReInit2: switch recovery model to SIMPLE and back to FULL - breaks the log chain.
+          # A new FULL backup establishes the new chain; the following LOG backup begins it (BeginsLogChain).
+          Set-DbaDbRecoveryModel -SqlInstance localhost -Database ReInit2 -RecoveryModel Simple -Confirm:$false
+          Set-DbaDbRecoveryModel -SqlInstance localhost -Database ReInit2 -RecoveryModel Full -Confirm:$false
+          Invoke-DbaQuery -SqlInstance localhost -Database ReInit2 -Query "INSERT INTO dbo.Marker(Id) VALUES(2);"
+          Backup-DbaDatabase -SqlInstance localhost -Path C:\backup\FULL\ -Database ReInit2 -Type Full -CreateFolder -TimeStampFormat yyyyMMddHHmmss
+          Backup-DbaDatabase -SqlInstance localhost -Path C:\backup\LOG\ -Database ReInit2 -Type LOG -CreateFolder -TimeStampFormat yyyyMMddHHmmss
+
+          # ReInit3: normal continuation of the same log chain - must NOT be re-initialized.
+          # No new FULL backup, just another LOG backup that should be applied normally.
+          Invoke-DbaQuery -SqlInstance localhost -Database ReInit3 -Query "INSERT INTO dbo.Marker(Id) VALUES(2);"
+          Backup-DbaDatabase -SqlInstance localhost -Path C:\backup\LOG\ -Database ReInit3 -Type LOG -CreateFolder -TimeStampFormat yyyyMMddHHmmss
+
+      - name: Wait for scenarios to be applied
+        run: |
+          $targets = 'ReInit1_Copy','ReInit2_Copy','ReInit3_Copy'
+          $LoopCount=0; $MaxLoopCount=120; $ready=$false
+          while(-not $ready -and $LoopCount -lt $MaxLoopCount) {
+            Start-Sleep -s 2; $LoopCount++
+            $ok=0
+            foreach($t in $targets) {
+              try {
+                if(Get-DbaDatabase -SqlInstance localhost -Database $t -Status Standby) {
+                  $res = Invoke-DbaQuery -SqlInstance localhost -Database $t -As PSObject -Query "SELECT MAX(Id) AS Id FROM dbo.Marker"
+                  if($res.Id -eq 2) { $ok++ }
+                }
+              } catch { }
+            }
+            if($ok -eq $targets.Count) { $ready=$true }
+            Write-Output "Waiting for scenarios to be applied ($ok/$($targets.Count))..."
+          }
+          if(-not $ready) {
+            Get-ChildItem -Path C:\sql-log-shipping-service\Logs | Get-Content
+            throw "Timeout waiting for scenarios to be applied"
+          }
+          Write-Output "All copies now reflect marker = 2."
+
+      - name: Verify no further re-initialization (idempotency)
+        run: |
+          # Re-initialization must be one-shot.  Capture the full-restore counts, wait a couple of poll
+          # cycles, then confirm they have not increased (i.e. we are not stuck re-initializing in a loop).
+          function Get-FullRestoreCounts {
+            $counts = @{}
+            foreach($db in 'ReInit1_Copy','ReInit2_Copy','ReInit3_Copy') {
+              $counts[$db] = (Invoke-DbaQuery -SqlInstance localhost -As PSObject -Query "SELECT COUNT(*) AS C FROM msdb.dbo.restorehistory WHERE destination_database_name='$db' AND restore_type='D';").C
+            }
+            return $counts
+          }
+          $before = Get-FullRestoreCounts
+          Write-Output "Full-restore counts before wait: $($before | Out-String)"
+          Start-Sleep -s 15
+          $after = Get-FullRestoreCounts
+          Write-Output "Full-restore counts after wait: $($after | Out-String)"
+          foreach($db in $after.Keys) {
+            if($after[$db] -ne $before[$db]) {
+              Get-ChildItem -Path C:\sql-log-shipping-service\Logs | Get-Content
+              throw "Re-initialization is not idempotent for $db (full restores went from $($before[$db]) to $($after[$db]))"
+            }
+          }
+          Write-Output "No further re-initialization detected - re-initialization is one-shot."
+
+      - name: Output Logs
+        if: always()
+        run: |
+          Get-ChildItem -Path C:\sql-log-shipping-service\Logs | Get-Content
+
+      - name: Run Pester Tests for Re-initialize
+        run: |
+          Install-Module Pester -Force -SkipPublisherCheck
+          Import-Module Pester
+          $config = New-PesterConfiguration
+          $config.Run.Path = 'test\CI_Workflow-Reinitialize.Tests.ps1'
+          $config.Output.Verbosity = 'Detailed'
+          $config.TestResult.Enabled = $true
+          $config.TestResult.OutputFormat = 'NUnitXml'
+          $config.TestResult.OutputPath = 'test-results\reinitialize.xml'
+          $config.Run.PassThru = $true
+          $result = Invoke-Pester -Configuration $config
+          if ($result.FailedCount -gt 0) {
+            throw "$($result.FailedCount) Pester test(s) failed"
+          }
+
+      - name: Collect diagnostics
+        if: always()
+        run: |
+          New-Item -Path diagnostics\Logs -ItemType Directory -Force | Out-Null
+          Copy-Item -Path C:\sql-log-shipping-service\Logs\* -Destination diagnostics\Logs -Recurse -ErrorAction SilentlyContinue
+
+      - name: Upload diagnostics
+        if: always()
+        uses: actions/upload-artifact@v5
+        with:
+          name: reinitialize-diagnostics
+          path: |
+            diagnostics\**\*
+            test-results\**\*
+          if-no-files-found: ignore
+
+  build-noreinit:
+    name: Build & Test No-Reinitialize (safety)
+    runs-on: windows-latest
+    defaults:
+      run:
+        shell: pwsh
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7
+
+      - name: Setup
+        uses: actions/setup-dotnet@v5
+        with:
+          dotnet-version: 10.0.x
+
+      - name: Build solution
+        run: dotnet build sql-log-shipping-service\LogShippingService.csproj -p:Configuration=Release -o Build
+
+      - name: Install SQL
+        uses: potatoqualitee/mssqlsuite@v1.12
+        with:
+          install: sqlengine
+          collation: Latin1_General_BIN
+
+      - name: DBATools
+        run: |
+          Install-Module dbatools -Force
+          Set-DbatoolsConfig -FullName sql.connection.trustcert -Value $true -Register
+
+      - name: Create Databases (initial state)
+        run: |
+          # Only the broken-chain scenarios are needed for the negative test.
+          # ReInit1 - source will be dropped & re-created (new incarnation)
+          # ReInit2 - source recovery model switched to SIMPLE and back to FULL (broken log chain)
+          New-DbaDatabase -SqlInstance localhost -Name ReInit1,ReInit2 -RecoveryModel FULL
+          foreach($db in 'ReInit1','ReInit2') {
+            Invoke-DbaQuery -SqlInstance localhost -Database $db -Query "CREATE TABLE dbo.Marker(Id INT NOT NULL); INSERT INTO dbo.Marker(Id) VALUES(1);"
+          }
+          Backup-DbaDatabase -SqlInstance localhost -Path C:\backup\FULL\ -Database ReInit1,ReInit2 -Type Full -CreateFolder -TimeStampFormat yyyyMMddHHmmss
+          Backup-DbaDatabase -SqlInstance localhost -Path C:\backup\LOG\ -Database ReInit1,ReInit2 -Type LOG -CreateFolder -TimeStampFormat yyyyMMddHHmmss
+
+      - name: Deploy App
+        run: |
+          New-Item -Path C:\sql-log-shipping-service -ItemType Directory
+          New-Item -Path C:\Standby -ItemType Directory
+          Copy-Item -Path .\Build\* -Destination C:\sql-log-shipping-service -Recurse
+
+      - name: Configure (re-initialization disabled)
+        shell: cmd
+        run: |
+          "C:\sql-log-shipping-service\LogShippingService.exe" --Destination "Data Source=LOCALHOST;Integrated Security=True;Encrypt=True;Trust Server Certificate=True" --LogFilePath "C:\Backup\LOG\{DatabaseName}" --FullFilePath "C:\Backup\FULL\{DatabaseName}" --StandbyFileName "C:\Standby\{DatabaseName}_Standby.BAK" --RestoreDatabaseNameSuffix "_Copy" --EnableReinitialization false --DelayBetweenIterationsMs 5000
+
+      - name: Run service
+        run: |
+          sc.exe create "LogShippingService" binpath="C:\sql-log-shipping-service\LogShippingService.exe"
+          net start LogShippingService
+
+      - name: Wait for initial standby
+        run: |
+          $targets = 'ReInit1_Copy','ReInit2_Copy'
+          $LoopCount=0; $MaxLoopCount=60; $ready=$false
+          while(-not $ready -and $LoopCount -lt $MaxLoopCount) {
+            Start-Sleep -s 2; $LoopCount++
+            $ok=0
+            foreach($t in $targets) {
+              try {
+                if(Get-DbaDatabase -SqlInstance localhost -Database $t -Status Standby) {
+                  $res = Invoke-DbaQuery -SqlInstance localhost -Database $t -As PSObject -Query "SELECT MAX(Id) AS Id FROM dbo.Marker"
+                  if($res.Id -eq 1) { $ok++ }
+                }
+              } catch { }
+            }
+            if($ok -eq $targets.Count) { $ready=$true }
+            Write-Output "Waiting for initial standby ($ok/$($targets.Count))..."
+          }
+          if(-not $ready) {
+            Get-ChildItem -Path C:\sql-log-shipping-service\Logs | Get-Content
+            throw "Timeout waiting for initial standby"
+          }
+          Write-Output "All copies initialized (marker = 1)."
+
+      - name: Apply broken-chain scenarios
+        run: |
+          # ReInit1: drop & re-create the source (new incarnation).
+          Remove-DbaDatabase -SqlInstance localhost -Database ReInit1 -Confirm:$false
+          New-DbaDatabase -SqlInstance localhost -Name ReInit1 -RecoveryModel FULL
+          Invoke-DbaQuery -SqlInstance localhost -Database ReInit1 -Query "CREATE TABLE dbo.Marker(Id INT NOT NULL); INSERT INTO dbo.Marker(Id) VALUES(2);"
+          Backup-DbaDatabase -SqlInstance localhost -Path C:\backup\FULL\ -Database ReInit1 -Type Full -CreateFolder -TimeStampFormat yyyyMMddHHmmss
+          Backup-DbaDatabase -SqlInstance localhost -Path C:\backup\LOG\ -Database ReInit1 -Type LOG -CreateFolder -TimeStampFormat yyyyMMddHHmmss
+
+          # ReInit2: switch recovery model to SIMPLE and back to FULL - breaks the log chain.
+          Set-DbaDbRecoveryModel -SqlInstance localhost -Database ReInit2 -RecoveryModel Simple -Confirm:$false
+          Set-DbaDbRecoveryModel -SqlInstance localhost -Database ReInit2 -RecoveryModel Full -Confirm:$false
+          Invoke-DbaQuery -SqlInstance localhost -Database ReInit2 -Query "INSERT INTO dbo.Marker(Id) VALUES(2);"
+          Backup-DbaDatabase -SqlInstance localhost -Path C:\backup\FULL\ -Database ReInit2 -Type Full -CreateFolder -TimeStampFormat yyyyMMddHHmmss
+          Backup-DbaDatabase -SqlInstance localhost -Path C:\backup\LOG\ -Database ReInit2 -Type LOG -CreateFolder -TimeStampFormat yyyyMMddHHmmss
+
+      - name: Give the service time to (not) act
+        run: |
+          # With re-initialization disabled the service should keep failing to restore the broken chains.
+          # Wait a few poll cycles so any (incorrect) re-initialization would have had time to occur.
+          Start-Sleep -s 30
+
+      - name: Output Logs
+        if: always()
+        run: |
+          Get-ChildItem -Path C:\sql-log-shipping-service\Logs | Get-Content
+
+      - name: Run Pester Tests for No-Reinitialize
+        run: |
+          Install-Module Pester -Force -SkipPublisherCheck
+          Import-Module Pester
+          $config = New-PesterConfiguration
+          $config.Run.Path = 'test\CI_Workflow-NoReinit.Tests.ps1'
+          $config.Output.Verbosity = 'Detailed'
+          $config.TestResult.Enabled = $true
+          $config.TestResult.OutputFormat = 'NUnitXml'
+          $config.TestResult.OutputPath = 'test-results\noreinit.xml'
+          $config.Run.PassThru = $true
+          $result = Invoke-Pester -Configuration $config
+          if ($result.FailedCount -gt 0) {
+            throw "$($result.FailedCount) Pester test(s) failed"
+          }
+
+      - name: Collect diagnostics
+        if: always()
+        run: |
+          New-Item -Path diagnostics\Logs -ItemType Directory -Force | Out-Null
+          Copy-Item -Path C:\sql-log-shipping-service\Logs\* -Destination diagnostics\Logs -Recurse -ErrorAction SilentlyContinue
+
+      - name: Upload diagnostics
+        if: always()
+        uses: actions/upload-artifact@v5
+        with:
+          name: noreinitialize-diagnostics
+          path: |
+            diagnostics\**\*
+            test-results\**\*
+          if-no-files-found: ignore
+
+

--- a/.github/workflows/build-rename.yml
+++ b/.github/workflows/build-rename.yml
@@ -1,4 +1,4 @@
-name: SQL Log Shipping Service - Restore Copy
+name: SQL Log Shipping Service - Restore with rename & multiple paths
 
 on: 
     push:
@@ -8,6 +8,9 @@ jobs:
   build:
     name: Build & Test
     runs-on: windows-latest
+    defaults:
+      run:
+        shell: pwsh
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,6 +8,9 @@ jobs:
   build:
     name: Build & Test
     runs-on: windows-latest
+    defaults:
+      run:
+        shell: pwsh
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/tag-create-release.yml
+++ b/.github/workflows/tag-create-release.yml
@@ -22,7 +22,7 @@ jobs:
 
       - name: Get Version
         id: GetVersion 
-        shell: powershell
+        shell: pwsh
         run: | 
           $path = [System.IO.Path]::Combine((Get-Location),"Build\LogShippingService.dll")
           $version = [System.Reflection.Assembly]::LoadFrom($path).GetName().Version
@@ -30,7 +30,7 @@ jobs:
           Write-Output "BUILD_NUMBER=$($version.ToString(3))" >> $env:GITHUB_OUTPUT
 
       - name: Zip
-        shell: powershell
+        shell: pwsh
         run: | 
           $zipPath = "LogShippingService_${{steps.GetVersion.outputs.BUILD_NUMBER}}-unsigned.zip"
           Compress-Archive -Path "Build\*" -DestinationPath $zipPath

--- a/sql-log-shipping-service-tests/ClassifyLogTests.cs
+++ b/sql-log-shipping-service-tests/ClassifyLogTests.cs
@@ -1,0 +1,158 @@
+using System.Numerics;
+using LogShippingService;
+
+namespace LogShippingServiceTests
+{
+    /// <summary>
+    /// Table-driven unit tests for <see cref="LogShipping.ClassifyLog"/> - the pure decision that folds the restore delay,
+    /// the log's LSN position relative to the current redo point, and the chain integrity into a single
+    /// <see cref="LogShipping.LogRestoreAction"/>.  These pin down the full positional + chain matrix without a SQL Server instance.
+    /// </summary>
+    [TestClass]
+    public class ClassifyLogTests
+    {
+        private static readonly DateTime Reference = new(2024, 1, 1, 12, 0, 0, DateTimeKind.Utc);
+        private static readonly DateTime SameIncarnation = Reference.AddDays(-30);
+        private static readonly DateTime NewerIncarnation = Reference.AddDays(1);
+        private const long Redo = 200;
+
+        private static BackupHeader Header(
+            long firstLSN,
+            long lastLSN,
+            DateTime? backupFinishDate = null,
+            DateTime? databaseCreationDate = null,
+            bool beginsLogChain = false)
+        {
+            return new BackupHeader
+            {
+                BackupFinishDate = backupFinishDate ?? Reference,          // default: not newer than reference (chain guard => Ok)
+                DatabaseCreationDate = databaseCreationDate ?? SameIncarnation,
+                BeginsLogChain = beginsLogChain,
+                FirstLSN = new BigInteger(firstLSN),
+                LastLSN = new BigInteger(lastLSN)
+            };
+        }
+
+        private static LogShipping.LogRestoreAction Classify(
+            BackupHeader header,
+            DateTime? currentChainCreationDate,
+            BigInteger? redoStart = null,
+            int restoreDelayMins = 0)
+        {
+            return LogShipping.ClassifyLog(header, currentChainCreationDate, Reference, redoStart ?? new BigInteger(Redo), Reference, restoreDelayMins);
+        }
+
+        // ----- Restore delay (takes precedence over everything) -----
+
+        [TestMethod]
+        public void WithinRestoreDelay_IsWaitDelay()
+        {
+            var header = Header(100, 250, backupFinishDate: Reference.AddMinutes(-5)); // finished 5 min before "now" (Reference)
+            var action = LogShipping.ClassifyLog(header, SameIncarnation, Reference, new BigInteger(Redo), now: Reference, restoreDelayMins: 10);
+            Assert.AreEqual(LogShipping.LogRestoreAction.WaitDelay, action);
+        }
+
+        [TestMethod]
+        public void DelayElapsed_IsNotWaitDelay()
+        {
+            var header = Header(100, 250, backupFinishDate: Reference.AddMinutes(-20));
+            var action = LogShipping.ClassifyLog(header, SameIncarnation, Reference, new BigInteger(Redo), now: Reference, restoreDelayMins: 10);
+            Assert.AreEqual(LogShipping.LogRestoreAction.Apply, action);
+        }
+
+        // ----- Position: LastRestored (FirstLSN <= redo && LastLSN == redo) -----
+
+        [TestMethod]
+        public void ExactTip_IsLastRestored()
+        {
+            var action = Classify(Header(100, Redo), SameIncarnation);
+            Assert.AreEqual(LogShipping.LogRestoreAction.LastRestored, action);
+        }
+
+        [TestMethod]
+        public void ExactTip_NewerIncarnation_IsSourceRecreated()
+        {
+            var header = Header(100, Redo, backupFinishDate: Reference.AddMinutes(10), databaseCreationDate: NewerIncarnation);
+            Assert.AreEqual(LogShipping.LogRestoreAction.SourceRecreated, Classify(header, SameIncarnation));
+        }
+
+        // ----- Position: Apply (FirstLSN <= redo && LastLSN > redo) -----
+
+        [TestMethod]
+        public void SpansRedoPoint_IsApply()
+        {
+            var action = Classify(Header(100, 250), SameIncarnation);
+            Assert.AreEqual(LogShipping.LogRestoreAction.Apply, action);
+        }
+
+        [TestMethod]
+        public void SpansRedoPoint_NewerIncarnation_IsSourceRecreated()
+        {
+            var header = Header(100, 250, backupFinishDate: Reference.AddMinutes(10), databaseCreationDate: NewerIncarnation);
+            Assert.AreEqual(LogShipping.LogRestoreAction.SourceRecreated, Classify(header, SameIncarnation));
+        }
+
+        [TestMethod]
+        public void SpansRedoPoint_BrokenChainDoesNotDivert_StaysApply()
+        {
+            // A "Broken" chain status must NOT divert a spanning log (preserves original behaviour - only Recreated diverts here).
+            var header = Header(100, 250, backupFinishDate: Reference.AddMinutes(10), beginsLogChain: true);
+            Assert.AreEqual(LogShipping.LogRestoreAction.Apply, Classify(header, currentChainCreationDate: null));
+        }
+
+        // ----- Position: TooOld (FirstLSN < redo) -----
+
+        [TestMethod]
+        public void EntirelyBeforeRedoPoint_IsTooOld()
+        {
+            var action = Classify(Header(150, 180), SameIncarnation);
+            Assert.AreEqual(LogShipping.LogRestoreAction.TooOld, action);
+        }
+
+        [TestMethod]
+        public void TooOld_BrokenChain_IsChainBroken()
+        {
+            var header = Header(150, 180, backupFinishDate: Reference.AddMinutes(10), beginsLogChain: true);
+            Assert.AreEqual(LogShipping.LogRestoreAction.ChainBroken, Classify(header, currentChainCreationDate: null));
+        }
+
+        [TestMethod]
+        public void TooOld_NewerIncarnation_IsSourceRecreated()
+        {
+            var header = Header(150, 180, backupFinishDate: Reference.AddMinutes(10), databaseCreationDate: NewerIncarnation);
+            Assert.AreEqual(LogShipping.LogRestoreAction.SourceRecreated, Classify(header, SameIncarnation));
+        }
+
+        // ----- Position: TooRecent (FirstLSN > redo) -----
+
+        [TestMethod]
+        public void EntirelyAfterRedoPoint_IsTooRecent()
+        {
+            var action = Classify(Header(300, 400), SameIncarnation);
+            Assert.AreEqual(LogShipping.LogRestoreAction.TooRecent, action);
+        }
+
+        [TestMethod]
+        public void TooRecent_BeginsNewChainAhead_IsChainBroken()
+        {
+            var header = Header(300, 400, backupFinishDate: Reference.AddMinutes(10), beginsLogChain: true);
+            Assert.AreEqual(LogShipping.LogRestoreAction.ChainBroken, Classify(header, SameIncarnation));
+        }
+
+        [TestMethod]
+        public void TooRecent_NewerIncarnation_IsSourceRecreated()
+        {
+            var header = Header(300, 400, backupFinishDate: Reference.AddMinutes(10), databaseCreationDate: NewerIncarnation);
+            Assert.AreEqual(LogShipping.LogRestoreAction.SourceRecreated, Classify(header, SameIncarnation));
+        }
+
+        // ----- No redo point yet (redoStart == null) -----
+
+        [TestMethod]
+        public void NullRedoStart_IsApply()
+        {
+            var action = LogShipping.ClassifyLog(Header(100, 250), SameIncarnation, Reference, redoStart: null, now: Reference, restoreDelayMins: 0);
+            Assert.AreEqual(LogShipping.LogRestoreAction.Apply, action);
+        }
+    }
+}

--- a/sql-log-shipping-service-tests/LogChainStatusTests.cs
+++ b/sql-log-shipping-service-tests/LogChainStatusTests.cs
@@ -1,0 +1,157 @@
+using System.Numerics;
+using LogShippingService;
+
+namespace LogShippingServiceTests
+{
+    /// <summary>
+    /// Table-driven unit tests for <see cref="LogShipping.GetLogChainStatus"/>.
+    /// This is the pure decision logic that classifies whether a log backup continues the current chain,
+    /// belongs to a re-created source database, or begins a broken/reset chain.  These tests pin down every
+    /// branch (including the BackupFinishDate stale-file guard) without requiring a SQL Server instance.
+    /// </summary>
+    [TestClass]
+    public class LogChainStatusTests
+    {
+        private static readonly DateTime Reference = new(2024, 1, 1, 12, 0, 0, DateTimeKind.Utc);
+
+        private static BackupHeader Header(
+            DateTime? backupFinishDate = null,
+            DateTime? databaseCreationDate = null,
+            bool beginsLogChain = false,
+            long firstLSN = 100,
+            long lastLSN = 200)
+        {
+            return new BackupHeader
+            {
+                BackupFinishDate = backupFinishDate ?? Reference.AddMinutes(10),
+                DatabaseCreationDate = databaseCreationDate ?? Reference.AddDays(-30),
+                BeginsLogChain = beginsLogChain,
+                FirstLSN = new BigInteger(firstLSN),
+                LastLSN = new BigInteger(lastLSN)
+            };
+        }
+
+        [TestMethod]
+        public void StaleFile_NotNewerThanReference_IsOk_EvenWhenBeginsNewChain()
+        {
+            // A backup whose finish date is not newer than the last log we restored must never be treated as
+            // a broken chain - guards the destructive re-initialization against stale / out-of-order files.
+            var header = Header(
+                backupFinishDate: Reference,               // == reference (boundary: <=)
+                databaseCreationDate: Reference.AddDays(1), // newer incarnation ...
+                beginsLogChain: true,                       // ... and begins a new chain ...
+                firstLSN: 500);                             // ... ahead of the redo point
+
+            var status = LogShipping.GetLogChainStatus(header, Reference.AddDays(-30), Reference, redoStart: 100);
+
+            Assert.AreEqual(LogShipping.LogChainStatus.Ok, status);
+        }
+
+        [TestMethod]
+        public void StaleFile_FinishDateOlderThanReference_IsOk()
+        {
+            var header = Header(backupFinishDate: Reference.AddMinutes(-5), databaseCreationDate: Reference.AddDays(1), beginsLogChain: true, firstLSN: 500);
+
+            var status = LogShipping.GetLogChainStatus(header, Reference.AddDays(-30), Reference, redoStart: 100);
+
+            Assert.AreEqual(LogShipping.LogChainStatus.Ok, status);
+        }
+
+        [TestMethod]
+        public void NewerDatabaseCreationDate_IsRecreated()
+        {
+            var header = Header(
+                backupFinishDate: Reference.AddMinutes(10),
+                databaseCreationDate: Reference.AddDays(1)); // newer than the current chain's creation date
+
+            var status = LogShipping.GetLogChainStatus(header, Reference.AddDays(-30), Reference, redoStart: 100);
+
+            Assert.AreEqual(LogShipping.LogChainStatus.Recreated, status);
+        }
+
+        [TestMethod]
+        public void RecreatedTakesPrecedenceOverBrokenChain()
+        {
+            // Both a newer creation date and BeginsLogChain - re-created is the more specific classification.
+            var header = Header(
+                backupFinishDate: Reference.AddMinutes(10),
+                databaseCreationDate: Reference.AddDays(1),
+                beginsLogChain: true,
+                firstLSN: 500);
+
+            var status = LogShipping.GetLogChainStatus(header, Reference.AddDays(-30), Reference, redoStart: 100);
+
+            Assert.AreEqual(LogShipping.LogChainStatus.Recreated, status);
+        }
+
+        [TestMethod]
+        public void BeginsLogChain_AheadOfRedoPoint_IsBroken()
+        {
+            // Same incarnation (creation date matches) but a new chain has started ahead of our redo point
+            // e.g. the recovery model was switched to SIMPLE and back to FULL.
+            var creationDate = Reference.AddDays(-30);
+            var header = Header(
+                backupFinishDate: Reference.AddMinutes(10),
+                databaseCreationDate: creationDate,
+                beginsLogChain: true,
+                firstLSN: 500);
+
+            var status = LogShipping.GetLogChainStatus(header, creationDate, Reference, redoStart: 100);
+
+            Assert.AreEqual(LogShipping.LogChainStatus.Broken, status);
+        }
+
+        [TestMethod]
+        public void BeginsLogChain_NoReferenceChain_IsBroken()
+        {
+            // No current chain reference yet - a log that begins a new chain can't be bridged.
+            var header = Header(backupFinishDate: Reference.AddMinutes(10), beginsLogChain: true, firstLSN: 50);
+
+            var status = LogShipping.GetLogChainStatus(header, currentChainCreationDate: null, Reference, redoStart: 100);
+
+            Assert.AreEqual(LogShipping.LogChainStatus.Broken, status);
+        }
+
+        [TestMethod]
+        public void BeginsLogChain_NullRedoStart_IsBroken()
+        {
+            var creationDate = Reference.AddDays(-30);
+            var header = Header(backupFinishDate: Reference.AddMinutes(10), databaseCreationDate: creationDate, beginsLogChain: true, firstLSN: 50);
+
+            var status = LogShipping.GetLogChainStatus(header, creationDate, Reference, redoStart: null);
+
+            Assert.AreEqual(LogShipping.LogChainStatus.Broken, status);
+        }
+
+        [TestMethod]
+        public void BeginsLogChain_AtOrBeforeRedoPoint_WithReferenceChain_IsOk()
+        {
+            // Our own chain's original first log re-appearing (pulled in by a reProcess walk-back) is safe to skip.
+            var creationDate = Reference.AddDays(-30);
+            var header = Header(
+                backupFinishDate: Reference.AddMinutes(10),
+                databaseCreationDate: creationDate,
+                beginsLogChain: true,
+                firstLSN: 100); // FirstLSN == redoStart (not ahead)
+
+            var status = LogShipping.GetLogChainStatus(header, creationDate, Reference, redoStart: 100);
+
+            Assert.AreEqual(LogShipping.LogChainStatus.Ok, status);
+        }
+
+        [TestMethod]
+        public void ContinuesChain_NotBeginningNewChain_IsOk()
+        {
+            var creationDate = Reference.AddDays(-30);
+            var header = Header(
+                backupFinishDate: Reference.AddMinutes(10),
+                databaseCreationDate: creationDate,
+                beginsLogChain: false,
+                firstLSN: 500);
+
+            var status = LogShipping.GetLogChainStatus(header, creationDate, Reference, redoStart: 100);
+
+            Assert.AreEqual(LogShipping.LogChainStatus.Ok, status);
+        }
+    }
+}

--- a/sql-log-shipping-service-tests/UnitTests.cs
+++ b/sql-log-shipping-service-tests/UnitTests.cs
@@ -38,10 +38,11 @@ namespace LogShippingServiceTests
                 KillUserConnections = false,
                 MaxProcessingTimeMins = 20,
                 AccessKey = "myAccessKey",
-                SecretKey = "mySecretKey"
+                SecretKey = "mySecretKey",
+                EnableReinitialization = true
             };
             // Pass values to LogShippingService.exe command line
-            var commandLine = $"--ContainerUrl {options.ContainerUrl} --Destination \"{options.Destination}\" --DiffFilePath \"{options.DiffFilePath}\" --FullFilePath \"{options.FullFilePath}\" --LogFilePath \"{options.LogFilePath}\" --MaxBackupAgeForInitialization {options.MaxBackupAgeForInitialization} --MoveDataFolder \"{options.MoveDataFolder}\" --MoveFileStreamFolder \"{options.MoveFileStreamFolder}\" --MoveLogFolder \"{options.MoveLogFolder}\" --MSDBPathFind \"{options.MSDBPathFind}\" --MSDBPathReplace \"{options.MSDBPathReplace}\" --PollForNewDatabasesCron \"{options.PollForNewDatabasesCron}\" --PollForNewDatabasesFrequency {options.PollForNewDatabasesFrequency} --ReadOnlyFilePath \"{options.ReadOnlyFilePath}\" --RecoverPartialBackupWithoutReadOnly {options.RecoverPartialBackupWithoutReadOnly} --SASToken \"{options.SASToken}\" --SourceConnectionString \"{options.SourceConnectionString}\" --Hours {string.Join(' ', options.Hours)} --StandbyFileName \"{options.StandbyFileName}\" --KillUserConnectionsWithRollbackAfter {options.KillUserConnectionsWithRollbackAfter} --KillUserConnections {options.KillUserConnections} --MaxProcessingTimeMins {options.MaxProcessingTimeMins} --AccessKey \"{options.AccessKey}\" --SecretKey \"{options.SecretKey}\"";
+            var commandLine = $"--ContainerUrl {options.ContainerUrl} --Destination \"{options.Destination}\" --DiffFilePath \"{options.DiffFilePath}\" --FullFilePath \"{options.FullFilePath}\" --LogFilePath \"{options.LogFilePath}\" --MaxBackupAgeForInitialization {options.MaxBackupAgeForInitialization} --MoveDataFolder \"{options.MoveDataFolder}\" --MoveFileStreamFolder \"{options.MoveFileStreamFolder}\" --MoveLogFolder \"{options.MoveLogFolder}\" --MSDBPathFind \"{options.MSDBPathFind}\" --MSDBPathReplace \"{options.MSDBPathReplace}\" --PollForNewDatabasesCron \"{options.PollForNewDatabasesCron}\" --PollForNewDatabasesFrequency {options.PollForNewDatabasesFrequency} --ReadOnlyFilePath \"{options.ReadOnlyFilePath}\" --RecoverPartialBackupWithoutReadOnly {options.RecoverPartialBackupWithoutReadOnly} --SASToken \"{options.SASToken}\" --SourceConnectionString \"{options.SourceConnectionString}\" --Hours {string.Join(' ', options.Hours)} --StandbyFileName \"{options.StandbyFileName}\" --KillUserConnectionsWithRollbackAfter {options.KillUserConnectionsWithRollbackAfter} --KillUserConnections {options.KillUserConnections} --MaxProcessingTimeMins {options.MaxProcessingTimeMins} --AccessKey \"{options.AccessKey}\" --SecretKey \"{options.SecretKey}\" --EnableReinitialization {options.EnableReinitialization}";
 
             // Call LogShippingService.exe with the command line arguments
             var p = new Process()
@@ -63,7 +64,7 @@ namespace LogShippingServiceTests
 
             // Read the process output
             string output = p.StandardOutput.ReadToEnd();
-            Assert.AreNotSame(output, "");
+            Assert.AreNotSame("", output);
 
             var configuration = new ConfigurationBuilder()
                 .SetBasePath(Directory.GetCurrentDirectory())
@@ -95,6 +96,7 @@ namespace LogShippingServiceTests
             Assert.AreEqual(options.MaxProcessingTimeMins, config.MaxProcessingTimeMins);
             Assert.AreEqual(options.AccessKey, config.AccessKey);
             Assert.AreEqual(options.SecretKey, config.SecretKey); //Should be encrypted
+            Assert.AreEqual(options.EnableReinitialization, config.EnableReinitialization);
 
             var json = File.ReadAllText(Config.ConfigFile);
             // Check that the secret key and access key are not stored plaintext

--- a/sql-log-shipping-service/AssemblyInfo.cs
+++ b/sql-log-shipping-service/AssemblyInfo.cs
@@ -1,4 +1,5 @@
 using System.Reflection;
+using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
 // In SDK-style projects such as this one, several assembly attributes that were historically
@@ -24,3 +25,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 [assembly: AssemblyVersion("2.2.0")]
+
+// Expose internal members to the unit test project (used to test pure decision logic such as
+// LogShipping.GetLogChainStatus without requiring a SQL Server instance).
+[assembly: InternalsVisibleTo("LogShippingServiceTests")]

--- a/sql-log-shipping-service/AuditLog.cs
+++ b/sql-log-shipping-service/AuditLog.cs
@@ -1,0 +1,21 @@
+using Serilog;
+
+namespace LogShippingService
+{
+    /// <summary>
+    /// Provides a logger tagged so that database re-initialization events - a database was re-initialized, or requires manual
+    /// re-initialization - are written to a dedicated audit log in addition to the main log.  These events are rare but significant
+    /// (they involve dropping a database), so an easy to find, separate record is kept.
+    /// </summary>
+    internal static class AuditLog
+    {
+        /// <summary>Log property used to tag re-initialization events so a dedicated sink can filter on them.</summary>
+        public const string ReinitializationProperty = "Reinitialization";
+
+        /// <summary>
+        /// Logger for re-initialization events.  Events are written to the main log and, via the tagged property, to the dedicated
+        /// re-initialization log.  Resolved from the current Log.Logger on each access so it always uses the configured logger.
+        /// </summary>
+        public static ILogger Reinitialization => Log.ForContext(ReinitializationProperty, true);
+    }
+}

--- a/sql-log-shipping-service/BackupHeader.cs
+++ b/sql-log-shipping-service/BackupHeader.cs
@@ -144,6 +144,11 @@ namespace LogShippingService
             SetFromRow(row);
         }
 
+        /// <summary>Parameterless constructor used by unit tests to build headers with specific values.</summary>
+        internal BackupHeader()
+        {
+        }
+
         private void SetFromRow(DataRow row)
         {
             BackupName = row["BackupName"] as string;

--- a/sql-log-shipping-service/CommandLineOptions.cs
+++ b/sql-log-shipping-service/CommandLineOptions.cs
@@ -64,6 +64,9 @@ namespace LogShippingService
         [Option("InitializeSimple", Required = false, HelpText = @"Databases in SIMPLE recovery model are excluded by default.")]
         public bool? InitializeSimple { get; set; }
 
+        [Option("EnableReinitialization", Required = false, HelpText = @"Automatically drop & re-initialize a log-shipped database when its log chain can no longer be continued - i.e. the source database was dropped & re-created with the same name, or the log chain was otherwise broken (e.g. recovery model switched to SIMPLE and back to FULL).  Default false as it drops the destination database.")]
+        public bool? EnableReinitialization { get; set; }
+
         [Option("IncludedDatabases", Required = false, HelpText = @"List of databases to include.  All other databases are excluded. e.g. --IncludedDatabases ""DB1"" ""DB2""")]
         public IEnumerable<string>? IncludedDatabases { get; set; }
 
@@ -96,6 +99,9 @@ namespace LogShippingService
 
         [Option("MaxThreads", Required = false, HelpText = @"Max number of threads to use for restore operations.")]
         public int? MaxThreads { get; set; }
+
+        [Option("MaxConcurrentInitializations", Required = false, HelpText = @"Max number of databases that can be (re)initialized from a FULL backup concurrently.  Defaults to MaxThreads.")]
+        public int? MaxConcurrentInitializations { get; set; }
 
         [Option("Hours", Required = false, HelpText = @"Hours that log restores are allowed to run. Set to -1 to include ALL hours (default).  e.g. --Hours 0 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23")]
         public IEnumerable<int>? Hours { get; set; }

--- a/sql-log-shipping-service/Config.cs
+++ b/sql-log-shipping-service/Config.cs
@@ -362,6 +362,10 @@ namespace LogShippingService
         [JsonProperty(DefaultValueHandling = DefaultValueHandling.Ignore)]
         public bool InitializeSimple { get; set; }
 
+        /// <summary>Option to automatically drop and re-initialize a log-shipped database when its log chain can no longer be continued.  This happens when the source database is dropped and re-created with the same name, or when the log chain is otherwise broken (e.g. the recovery model is switched to SIMPLE and back to FULL).  Detected via a newer DatabaseCreationDate or a new log chain (BeginsLogChain).  Default false as it involves dropping the destination database.</summary>
+        [JsonProperty(DefaultValueHandling = DefaultValueHandling.Ignore)]
+        public bool EnableReinitialization { get; set; }
+
         /// <summary>Max age of backups to use for initialization in days.  Defaults to 14 days. Prevents old backups been used to initialize. </summary>
         public int MaxBackupAgeForInitialization { get; set; } = MaxBackupAgeForInitializationDefault;
 
@@ -432,6 +436,16 @@ namespace LogShippingService
         /// <summary>Max number of threads to use for log restores and database initialization (each can use up to MaxThreads)</summary>
         public int MaxThreads { get; set; } = MaxThreadsDefault;
 
+        private int? _maxConcurrentInitializations;
+
+        /// <summary>Max number of databases that can be (re)initialized from a FULL backup concurrently.  Initialization and re-initialization share this limit as both perform a FULL restore.  Defaults to MaxThreads.</summary>
+        [JsonProperty(DefaultValueHandling = DefaultValueHandling.Ignore)]
+        public int MaxConcurrentInitializations
+        {
+            get => _maxConcurrentInitializations ?? MaxThreads;
+            set => _maxConcurrentInitializations = value;
+        }
+
         [JsonProperty(DefaultValueHandling = DefaultValueHandling.Ignore)]
         public int RestoreDelayMins { get; set; }
 
@@ -475,6 +489,11 @@ namespace LogShippingService
         public bool ShouldSerializeMaxThreads()
         {
             return MaxThreads != MaxThreadsDefault;
+        }
+
+        public bool ShouldSerializeMaxConcurrentInitializations()
+        {
+            return _maxConcurrentInitializations.HasValue;
         }
 
         public bool ShouldSerializeMaxProcessingTimeMins()
@@ -627,6 +646,11 @@ namespace LogShippingService
                                 InitializeSimple = (bool)opts.InitializeSimple;
                             }
 
+                            if (opts.EnableReinitialization != null)
+                            {
+                                EnableReinitialization = (bool)opts.EnableReinitialization;
+                            }
+
                             if (opts.IncludedDatabases != null && args.Contains("--IncludedDatabases"))
                             {
                                 IncludedDatabases = opts.IncludedDatabases.Where(dbs => !string.IsNullOrEmpty(dbs))
@@ -683,6 +707,11 @@ namespace LogShippingService
                             if (opts.MaxThreads != null)
                             {
                                 MaxThreads = (int)opts.MaxThreads;
+                            }
+
+                            if (opts.MaxConcurrentInitializations != null)
+                            {
+                                MaxConcurrentInitializations = (int)opts.MaxConcurrentInitializations;
                             }
 
                             if (opts.ContainerUrl != null)

--- a/sql-log-shipping-service/DataHelper.cs
+++ b/sql-log-shipping-service/DataHelper.cs
@@ -159,5 +159,46 @@ namespace LogShippingService
             cn.Open();
             return BigInteger.Parse(cmd.ExecuteScalar().ToString() ?? throw new InvalidOperationException());
         }
+
+        /// <summary>
+        /// Get the state of a database from sys.databases.  Returns null if the database does not exist.
+        /// A log shipped database is either RESTORING (state = 1) or in STANDBY mode.
+        /// A database in STANDBY mode is ONLINE (state = 0) with is_in_standby = 1.
+        /// </summary>
+        public static (byte State, bool IsInStandby)? GetDatabaseState(string db, string connectionString)
+        {
+            using var cn = new SqlConnection(connectionString);
+            using var cmd = new SqlCommand("SELECT state, is_in_standby FROM sys.databases WHERE database_id = DB_ID(@db)", cn) { CommandTimeout = 0 };
+            cmd.Parameters.AddWithValue("@db", db);
+            cn.Open();
+            using var rdr = cmd.ExecuteReader();
+            if (!rdr.Read())
+            {
+                return null;
+            }
+            var state = Convert.ToByte(rdr["state"]);
+            var isInStandby = rdr["is_in_standby"] != DBNull.Value && Convert.ToBoolean(rdr["is_in_standby"]);
+            return (state, isInStandby);
+        }
+
+        /// <summary>
+        /// Drop a database that is in a RESTORING or STANDBY state.  RESTORING is sys.databases.state = 1; a database in STANDBY
+        /// mode is ONLINE (state = 0) with is_in_standby = 1.  An ONLINE database that is not in standby is never dropped -
+        /// an error is raised instead so callers do not silently continue.  Any open connections (e.g. for databases in STANDBY
+        /// mode) should be cleared first via LogShipping.KillUserConnections.
+        /// </summary>
+        public static void DropDatabase(string db, string connectionString)
+        {
+            var quoted = db.SqlQuote();
+            var literal = db.SqlSingleQuote();
+            var sql = $@"IF DB_ID({literal}) IS NOT NULL
+BEGIN
+    IF EXISTS (SELECT 1 FROM sys.databases WHERE database_id = DB_ID({literal}) AND (state = 1 /* RESTORING */ OR (state = 0 AND is_in_standby = 1) /* STANDBY */))
+        DROP DATABASE {quoted};
+    ELSE
+        RAISERROR('Refusing to drop %s - it is not in a RESTORING or STANDBY state.', 16, 1, {literal});
+END";
+            ExecuteWithTiming(sql, connectionString);
+        }
     }
 }

--- a/sql-log-shipping-service/DatabaseInitializerBase.cs
+++ b/sql-log-shipping-service/DatabaseInitializerBase.cs
@@ -3,6 +3,8 @@ using static LogShippingService.BackupHeader;
 using System.Reflection.PortableExecutable;
 using LogShippingService.FileHandling;
 using SerilogTimings;
+using System.Collections.Concurrent;
+using System.Threading.Channels;
 
 namespace LogShippingService
 {
@@ -14,29 +16,186 @@ namespace LogShippingService
 
         private static Config Config => AppConfig.Config;
 
-        protected void ProcessDB(string sourceDb, CancellationToken stoppingToken)
+        // Shared queue for initialization AND re-initialization.  Both perform a FULL restore, so they share a single bounded
+        // consumer pool (Config.MaxConcurrentInitializations) rather than competing with the log-restore worker pool.
+        private readonly Channel<InitRequest> _initQueue =
+            Channel.CreateUnbounded<InitRequest>(new UnboundedChannelOptions { SingleReader = false, SingleWriter = false });
+
+        // Databases currently queued or being (re)initialized, keyed by targetDb.  Used to dedup enqueue requests.
+        private readonly ConcurrentDictionary<string, InitReason> _inFlight = new(StringComparer.OrdinalIgnoreCase);
+
+        // A failed re-initialization is requeued (with a delay) up to this many attempts.  New-database initialization is not
+        // requeued here - it is naturally retried by the next poll iteration.
+        private const int MaxReinitAttempts = 3;
+
+        private static readonly TimeSpan ReinitRetryDelay = TimeSpan.FromMinutes(1);
+
+        /// <summary>
+        /// Queue a database to be (re)initialized from a FULL backup.  Deduplicated by target database and gated so log restores
+        /// are skipped until the (re)initialization completes.  Non-blocking - the actual restore runs on a consumer thread.
+        /// </summary>
+        internal void EnqueueInitialization(string sourceDb, string targetDb, InitReason reason, string? detail)
         {
-            var targetDb = GetDestinationDatabaseName(sourceDb);
-            if (!IsValidForInitialization(sourceDb, targetDb)) return;
-            if (stoppingToken.IsCancellationRequested) return;
+            if (!IsValidated)
+            {
+                AuditLog.Reinitialization.Error("Cannot {reason} {targetDb}. Initialization is not configured.  Handle it manually.  Detail: {detail}", reason, targetDb, detail);
+                return;
+            }
+            if (!_inFlight.TryAdd(targetDb, reason)) // Already queued or in progress
+            {
+                Log.Debug("Skipping {reason} for {targetDb}; already initializing.", reason, targetDb);
+                return;
+            }
+            LogShipping.InitializingDBs[targetDb.ToLower()] = targetDb; // Prevent log restores until (re)initialization is complete
+            if (!_initQueue.Writer.TryWrite(new InitRequest(sourceDb, targetDb, reason, detail)))
+            {
+                ReleaseGate(targetDb);
+                Log.Error("Failed to queue {reason} for {targetDb}", reason, targetDb);
+            }
+        }
+
+        /// <summary>Clear the dedup entry and the log-restore gate for a database once (re)initialization is terminal.</summary>
+        private void ReleaseGate(string targetDb)
+        {
+            _inFlight.TryRemove(targetDb, out _);
+            LogShipping.InitializingDBs.TryRemove(targetDb.ToLower(), out _); // Log restores can resume
+        }
+
+        /// <summary>Start the fixed-size pool of consumers that drain the (re)initialization queue.</summary>
+        private List<Task> StartInitializationConsumers(CancellationToken stoppingToken)
+        {
+            var count = Math.Max(1, Config.MaxConcurrentInitializations);
+            Log.Information("Starting {count} initialization consumer(s)", count);
+            var consumers = new List<Task>(count);
+            for (var i = 0; i < count; i++)
+            {
+                consumers.Add(Task.Run(() => ConsumeInitializationsAsync(stoppingToken), stoppingToken));
+            }
+            return consumers;
+        }
+
+        /// <summary>
+        /// Consume (re)initialization requests until cancellation.  In-flight restores are never cancelled mid-operation
+        /// (the cancellation token is only observed between requests).  A failed re-initialization is requeued with a delay.
+        /// </summary>
+        private async Task ConsumeInitializationsAsync(CancellationToken stoppingToken)
+        {
+            while (await _initQueue.Reader.WaitToReadAsync(stoppingToken))
+            {
+                while (_initQueue.Reader.TryRead(out var req))
+                {
+                    var requeued = false;
+                    try
+                    {
+                        var success = req.Reason == InitReason.Reinitialize
+                            ? RunReInitialize(req.SourceDb, req.TargetDb, req.Detail ?? string.Empty)
+                            : RunInitialize(req.SourceDb, req.TargetDb, stoppingToken);
+
+                        if (!success && req.Reason == InitReason.Reinitialize && req.Attempt < MaxReinitAttempts)
+                        {
+                            requeued = RequeueWithDelay(req with { Attempt = req.Attempt + 1 }, stoppingToken);
+                        }
+                        else if (!success && req.Reason == InitReason.Reinitialize)
+                        {
+                            AuditLog.Reinitialization.Error("Giving up re-initializing {targetDb} after {attempts} attempts.  A later log restore will re-detect the broken chain.  Detail: {detail}", req.TargetDb, req.Attempt, req.Detail);
+                        }
+                    }
+                    catch (Exception ex)
+                    {
+                        Log.Error(ex, "Unhandled error processing {reason} for {targetDb}", req.Reason, req.TargetDb);
+                    }
+                    finally
+                    {
+                        if (!requeued)
+                        {
+                            ReleaseGate(req.TargetDb); // Terminal outcome (success or gave up) - a requeued request keeps the gate held
+                        }
+                    }
+                }
+            }
+        }
+
+        /// <summary>Requeue a failed re-initialization after a delay, keeping the gate held so log restores stay blocked.</summary>
+        private bool RequeueWithDelay(InitRequest req, CancellationToken stoppingToken)
+        {
+            AuditLog.Reinitialization.Warning("Re-initialization of {targetDb} did not complete.  Retrying (attempt {attempt}/{max}) in {delay}.", req.TargetDb, req.Attempt, MaxReinitAttempts, ReinitRetryDelay);
+            _ = Task.Run(async () =>
+            {
+                try
+                {
+                    await Task.Delay(ReinitRetryDelay, stoppingToken);
+                }
+                catch (OperationCanceledException)
+                {
+                    ReleaseGate(req.TargetDb);
+                    return;
+                }
+                if (!_initQueue.Writer.TryWrite(req))
+                {
+                    ReleaseGate(req.TargetDb);
+                }
+            }, stoppingToken);
+            return true;
+        }
+
+        /// <summary>
+        /// Initialize a new database from a FULL backup.  Returns true when terminal (nothing more to do) - new-database
+        /// initialization is not requeued on failure; the next poll iteration retries it.
+        /// </summary>
+        private bool RunInitialize(string sourceDb, string targetDb, CancellationToken stoppingToken)
+        {
+            if (!IsValidForInitialization(sourceDb, targetDb)) return true; // Already exists / excluded - nothing to do
+            if (stoppingToken.IsCancellationRequested) return true;
             try
             {
-                if (LogShipping.InitializingDBs.TryAdd(sourceDb.ToLower(), sourceDb)) // To prevent log restores until initialization is complete
-                {
-                    DoProcessDB(sourceDb, targetDb);
-                }
-                else
-                {
-                    Log.Error("{sourceDb} is already initializing", sourceDb);
-                }
+                DoProcessDB(sourceDb, targetDb);
             }
             catch (Exception ex)
             {
                 Log.Error(ex, "Error initializing new database from backup {sourceDb}", sourceDb);
             }
-            finally
+            return true;
+        }
+
+        /// <summary>
+        /// Drop and re-initialize a database whose source log chain can no longer be continued - the source database was
+        /// re-created (dropped &amp; re-created with the same name), or the log chain was otherwise broken (e.g. the recovery
+        /// model was switched to SIMPLE and back to FULL).  Returns false if the restore did not complete so it can be retried.
+        /// </summary>
+        private bool RunReInitialize(string sourceDb, string targetDb, string reason)
+        {
+            // Only drop a database that is in a RESTORING or STANDBY state.  RESTORING is sys.databases.state = 1.
+            // A database in STANDBY mode is ONLINE (state = 0) with is_in_standby = 1.
+            // This guards against dropping a regular ONLINE database (e.g. one that isn't actually log shipped).
+            const byte onlineState = 0;
+            const byte restoringState = 1;
+            var state = DataHelper.GetDatabaseState(targetDb, Config.Destination);
+            var isRestoringOrStandby = state.HasValue && (state.Value.State == restoringState || (state.Value.State == onlineState && state.Value.IsInStandby));
+            if (!isRestoringOrStandby)
             {
-                LogShipping.InitializingDBs.TryRemove(sourceDb.ToLower(), out _); // Log restores can start after restore operations have completed
+                AuditLog.Reinitialization.Error("Cannot re-initialize {targetDb}. Expected the database to be in a RESTORING or STANDBY state but sys.databases state is {state}, is_in_standby: {isInStandby}. {targetDb} has NOT been dropped.", targetDb, state?.State.ToString() ?? "not found (database does not exist)", state?.IsInStandby ?? false, targetDb);
+                return true; // Not in a droppable state - don't retry
+            }
+
+            try
+            {
+                AuditLog.Reinitialization.Warning("Dropping {targetDb} so it can be re-initialized.  Reason: {reason}", targetDb, reason);
+                LogShipping.KillUserConnections(targetDb); // Clear any open connections (e.g. STANDBY) so the drop can proceed
+                DataHelper.DropDatabase(targetDb, Config.Destination);
+                DoProcessDB(sourceDb, targetDb);
+                // DoProcessDB handles initialization errors internally (logged without throwing) - verify the database exists before reporting success
+                if (DataHelper.GetDatabaseState(targetDb, Config.Destination) == null)
+                {
+                    AuditLog.Reinitialization.Error("{targetDb} was dropped but re-initialization did NOT complete.  Check the log for initialization errors.", targetDb);
+                    return false; // Database was dropped - retry until it is restored
+                }
+                AuditLog.Reinitialization.Warning("{targetDb} has been dropped and re-initialized from a current backup.", targetDb);
+                return true;
+            }
+            catch (Exception ex)
+            {
+                AuditLog.Reinitialization.Error(ex, "Error re-initializing {targetDb}.  Reason for re-initialization: {reason}", targetDb, reason);
+                return false; // Retry
             }
         }
 
@@ -64,31 +223,52 @@ namespace LogShippingService
             }
 
             long i = 0;
-            while (!stoppingToken.IsCancellationRequested)
+            var consumers = StartInitializationConsumers(stoppingToken);
+            try
             {
-                await WaitForNextInitializationAsync(i, stoppingToken);
-                i++;
-                if (stoppingToken.IsCancellationRequested) return;
-                try
+                while (!stoppingToken.IsCancellationRequested)
                 {
-                    DestinationDBs = DatabaseInfo.GetDatabaseInfo(Config.Destination);
-                }
-                catch (Exception ex)
-                {
-                    Log.Error(ex, "Error getting destination databases.");
-                    break;
-                }
-                try
-                {
-                    using (var op = Operation.Begin($"Initialize new databases iteration {i}"))
+                    await WaitForNextInitializationAsync(i, stoppingToken);
+                    i++;
+                    if (stoppingToken.IsCancellationRequested) return;
+                    try
                     {
-                        PollForNewDBs(stoppingToken);
-                        op.Complete();
+                        DestinationDBs = DatabaseInfo.GetDatabaseInfo(Config.Destination);
+                    }
+                    catch (Exception ex)
+                    {
+                        Log.Error(ex, "Error getting destination databases.");
+                        break;
+                    }
+                    try
+                    {
+                        using (var op = Operation.Begin($"Initialize new databases iteration {i}"))
+                        {
+                            PollForNewDBs(stoppingToken);
+                            op.Complete();
+                        }
+                    }
+                    catch (Exception ex)
+                    {
+                        Log.Error(ex, "Error running poll for new DBs");
                     }
                 }
+            }
+            finally
+            {
+                // Stop accepting new work, then wait for consumers to finish (in-flight restores are not cancelled mid-operation).
+                _initQueue.Writer.TryComplete();
+                try
+                {
+                    await Task.WhenAll(consumers);
+                }
+                catch (OperationCanceledException)
+                {
+                    Log.Information("Initialization consumers shutdown due to cancellation request");
+                }
                 catch (Exception ex)
                 {
-                    Log.Error(ex, "Error running poll for new DBs");
+                    Log.Error(ex, "Unexpected error during initialization consumer shutdown");
                 }
             }
             Log.Information("Poll for new DBs is shutdown");

--- a/sql-log-shipping-service/DatabaseInitializerFromDiskOrUrl.cs
+++ b/sql-log-shipping-service/DatabaseInitializerFromDiskOrUrl.cs
@@ -31,17 +31,11 @@ namespace LogShippingService
         {
             if (string.IsNullOrEmpty(Config.FullFilePath)) return;
 
-            Parallel.ForEach(FileHandler.FileHandlerInstance.GetDatabases(),
-                new ParallelOptions { MaxDegreeOfParallelism = Config.MaxThreads },
-                (database, state) =>
-                {
-                    if (stoppingToken.IsCancellationRequested)
-                    {
-                        state.Stop(); // Stop the loop if cancellation is requested
-                    }
-
-                    ProcessDB(database, stoppingToken);
-                });
+            foreach (var database in FileHandler.FileHandlerInstance.GetDatabases())
+            {
+                if (stoppingToken.IsCancellationRequested) break;
+                EnqueueInitialization(database, GetDestinationDatabaseName(database), InitReason.NewDatabase, null);
+            }
         }
 
         protected override void DoProcessDB(string sourceDb, string targetDb)

--- a/sql-log-shipping-service/DatabaseInitializerFromMSDB.cs
+++ b/sql-log-shipping-service/DatabaseInitializerFromMSDB.cs
@@ -52,12 +52,11 @@ namespace LogShippingService
             }
 
             Log.Information("NewDBs:{Count}", newDBs.Count);
-            Parallel.ForEach(newDBs.AsEnumerable(),
-                new ParallelOptions() { MaxDegreeOfParallelism = Config.MaxThreads },
-                newDb =>
-                {
-                    ProcessDB(newDb.Name, stoppingToken);
-                });
+            foreach (var newDb in newDBs)
+            {
+                if (stoppingToken.IsCancellationRequested) break;
+                EnqueueInitialization(newDb.Name, GetDestinationDatabaseName(newDb.Name), InitReason.NewDatabase, null);
+            }
         }
 
         /// <summary>

--- a/sql-log-shipping-service/InitRequest.cs
+++ b/sql-log-shipping-service/InitRequest.cs
@@ -1,0 +1,25 @@
+namespace LogShippingService
+{
+    /// <summary>
+    /// Why a database is being (re)initialized from a FULL backup.
+    /// </summary>
+    internal enum InitReason
+    {
+        /// <summary>A new source database was discovered that does not yet exist on the destination.</summary>
+        NewDatabase,
+
+        /// <summary>An existing log-shipped database must be dropped and re-initialized because its log chain can no longer be continued.</summary>
+        Reinitialize
+    }
+
+    /// <summary>
+    /// A unit of work for the shared initialization/re-initialization queue.  Both reasons perform a FULL restore, so they
+    /// share a single bounded consumer pool (see <see cref="DatabaseInitializerBase"/>).
+    /// </summary>
+    /// <param name="SourceDb">Source database name.</param>
+    /// <param name="TargetDb">Destination database name (the log-restore gate key).</param>
+    /// <param name="Reason">Whether this is a first-time initialization or a re-initialization.</param>
+    /// <param name="Detail">Optional human readable detail (e.g. the reason a re-initialization is required).</param>
+    /// <param name="Attempt">1-based attempt counter, incremented when a re-initialization is requeued after a failure.</param>
+    internal sealed record InitRequest(string SourceDb, string TargetDb, InitReason Reason, string? Detail, int Attempt = 1);
+}

--- a/sql-log-shipping-service/LogShipping.cs
+++ b/sql-log-shipping-service/LogShipping.cs
@@ -330,7 +330,7 @@ namespace LogShippingService
             {
                 try
                 {
-                    await RestoreLogsAsync(logFiles, item.SourceDb, item.TargetDb, reProcess, stoppingToken);
+                    await RestoreLogsAsync(logFiles, item.SourceDb, item.TargetDb, item.FromDate, reProcess, stoppingToken);
                     op.Complete();
                 }
                 catch (TimeoutException ex) when (ex.Message == "Max processing time exceeded")
@@ -349,7 +349,28 @@ namespace LogShippingService
                 {
                     await HandleTooRecentAsync(ex, item, processCount, stoppingToken);
                 }
+                catch (ReinitializeRequiredException ex)
+                {
+                    op.SetException(ex);
+                    ReInitializeDatabase(ex.SourceDb, ex.TargetDb, ex.Reason);
+                }
             }
+        }
+
+        /// <summary>
+        /// Queue a database to be dropped and re-initialized because its source log chain can no longer be continued - the
+        /// source database was re-created (dropped &amp; re-created with the same name), or the log chain was otherwise broken
+        /// (e.g. the recovery model was switched to SIMPLE and back to FULL).  The restore runs on the shared initialization
+        /// queue so the log-restore worker is not blocked.
+        /// </summary>
+        private void ReInitializeDatabase(string sourceDb, string targetDb, string reason)
+        {
+            if (_initializer == null)
+            {
+                AuditLog.Reinitialization.Error("Cannot re-initialize {targetDb}.  No initializer is configured.  Drop and re-initialize it manually.  Reason for re-initialization: {reason}", targetDb, reason);
+                return;
+            }
+            _initializer.EnqueueInitialization(sourceDb, targetDb, InitReason.Reinitialize, reason);
         }
 
         private async Task HandleTooRecentAsync(Exception ex, QueueItem item, int processCount, CancellationToken stoppingToken)
@@ -375,7 +396,7 @@ namespace LogShippingService
             }
         }
 
-        private static Task RestoreLogsAsync(IEnumerable<BackupFile> logFiles, string sourceDb, string targetDb, bool reProcess, CancellationToken stoppingToken)
+        private static Task RestoreLogsAsync(IEnumerable<BackupFile> logFiles, string sourceDb, string targetDb, DateTime fromDate, bool reProcess, CancellationToken stoppingToken)
         {
             BigInteger? redoStartOrPreviousLastLSN = null;
             if (Config.CheckHeaders)
@@ -388,6 +409,17 @@ namespace LogShippingService
             bool breakProcessingFlag = false;
             var stopAt = Config.StopAt > DateTime.MinValue && Config.StopAt < DateTime.MaxValue ? ", STOPAT=" + Config.StopAt.ToString("yyyy-MM-ddTHH:mm:ss.fff").SqlSingleQuote() : "";
             var earlierLogFound = false;
+
+            // DatabaseCreationDate of the last log that belongs to the current chain (last restored / tip).
+            // Used to detect when the source database has been dropped & re-created: a re-created database has a newer creation date.
+            DateTime? currentChainCreationDate = null;
+            // BackupFinishDate of the last log that belongs to the current chain.  A broken/re-created chain is only ever acted on if the
+            // triggering log was genuinely taken after this - guards the destructive re-initialization against stale/out-of-order files.
+            DateTime? currentChainBackupFinishDate = null;
+            // Set when a log is found that breaks the current chain (source database re-created or the log chain was otherwise reset).
+            BackupHeader? brokenChainHeader = null;
+            string? brokenChainLogPath = null;
+            var brokenChainStatus = LogChainStatus.Ok;
             foreach (var logBackup in logFiles)
             {
                 if (DateTime.Now > maxTime)
@@ -444,46 +476,67 @@ namespace LogShippingService
                                 $"Header verification failed for {logBackup}.  Database: {header.DatabaseName}. Expected a backup for {targetDb}", BackupHeader.HeaderVerificationStatus.WrongDatabase);
                         }
 
-                        if (Config.RestoreDelayMins > 0 && DateTime.Now.Subtract(header.BackupFinishDate).TotalMinutes < Config.RestoreDelayMins)
+                        var action = ClassifyLog(header, currentChainCreationDate, currentChainBackupFinishDate ?? fromDate, redoStartOrPreviousLastLSN, DateTime.Now, Config.RestoreDelayMins);
+                        switch (action)
                         {
-                            Log.Information("Waiting to restore {logPath} & subsequent files.  Backup Finish Date: {BackupFinishDate}. Eligible for restore after {RestoreAfter}, RestoreDelayMins:{RestoreDelay}", logBackup.FilePath, header.BackupFinishDate, header.BackupFinishDate.AddMinutes(Config.RestoreDelayMins), Config.RestoreDelayMins);
-                            breakProcessingFlag = true;
-                            break;
-                        }
-                        else if (header.FirstLSN <= redoStartOrPreviousLastLSN && header.LastLSN == redoStartOrPreviousLastLSN)
-                        {
-                            if (reProcess) // Reprocess previous file if we got a too recent error, otherwise skip it
-                            {
-                                Log.Information("Re-processing {logPath}, FILE={Position}. FirstLSN: {FirstLSN}, LastLSN: {LastLSN}", logBackup.FilePath, header.Position, header.FirstLSN, header.LastLSN);
+                            case LogRestoreAction.WaitDelay:
+                                Log.Information("Waiting to restore {logPath} & subsequent files.  Backup Finish Date: {BackupFinishDate}. Eligible for restore after {RestoreAfter}, RestoreDelayMins:{RestoreDelay}", logBackup.FilePath, header.BackupFinishDate, header.BackupFinishDate.AddMinutes(Config.RestoreDelayMins), Config.RestoreDelayMins);
+                                breakProcessingFlag = true;
+                                break;
+
+                            case LogRestoreAction.SourceRecreated:
+                            case LogRestoreAction.ChainBroken:
+                                // The log can't be applied to the current chain because the source chain was reset
+                                // (the source database was re-created, or its recovery model was switched to SIMPLE and back to FULL).
+                                // Record only the first detection (the earliest divergence) but keep scanning the remaining files -
+                                // a later file may still connect to the redo point (e.g. out-of-order modified dates / reProcess walk-back),
+                                // in which case acting now would be premature.  Logging once avoids a warning per newer-incarnation file.
+                                if (brokenChainHeader == null)
+                                {
+                                    brokenChainStatus = action == LogRestoreAction.SourceRecreated ? LogChainStatus.Recreated : LogChainStatus.Broken;
+                                    brokenChainHeader = header;
+                                    brokenChainLogPath = logBackup.FilePath;
+                                    LogBrokenChainDetected(brokenChainStatus, sourceDb, logBackup.FilePath, header, currentChainCreationDate, redoStartOrPreviousLastLSN);
+                                }
                                 continue;
-                            }
-                            else
-                            {
-                                Log.Information("Skipping {logPath}, FILE={Position}. Found last log file restored.  FirstLSN: {FirstLSN}, LastLSN: {LastLSN}", logBackup.FilePath, header.Position, header.FirstLSN, header.LastLSN);
+
+                            case LogRestoreAction.LastRestored:
+                                currentChainCreationDate = header.DatabaseCreationDate; // This is the last log we restored - use its creation date as the reference for the current chain
+                                currentChainBackupFinishDate = header.BackupFinishDate;
+                                if (reProcess) // Reprocess previous file if we got a too recent error, otherwise skip it
+                                {
+                                    Log.Information("Re-processing {logPath}, FILE={Position}. FirstLSN: {FirstLSN}, LastLSN: {LastLSN}", logBackup.FilePath, header.Position, header.FirstLSN, header.LastLSN);
+                                }
+                                else
+                                {
+                                    Log.Information("Skipping {logPath}, FILE={Position}. Found last log file restored.  FirstLSN: {FirstLSN}, LastLSN: {LastLSN}", logBackup.FilePath, header.Position, header.FirstLSN, header.LastLSN);
+                                }
                                 continue;
-                            }
-                        }
-                        else if (header.FirstLSN <= redoStartOrPreviousLastLSN && header.LastLSN > redoStartOrPreviousLastLSN)
-                        {
-                            Log.Information("Header verification successful for {logPath}, FILE={Position}. FirstLSN: {FirstLSN}, LastLSN: {LastLSN}", logBackup.FilePath, header.Position, header.FirstLSN, header.LastLSN);
-                        }
-                        else if (header.FirstLSN < redoStartOrPreviousLastLSN)
-                        {
-                            earlierLogFound = true;
-                            Log.Information("Skipping {logPath}.  A later LSN is required: {RequiredLSN}, FirstLSN: {FirstLSN}, LastLSN: {LastLSN}", logBackup.FilePath, redoStartOrPreviousLastLSN, header.FirstLSN, header.LastLSN);
-                            continue;
-                        }
-                        else if (header.FirstLSN > redoStartOrPreviousLastLSN)
-                        {
-                            if (earlierLogFound && reProcess)
-                            {
-                                // The current log is too recent. We previously adjusted the search date looking for an earlier log.  Now we have found log files that are too early to apply, then this log that is too recent
-                                // The log chain appears to be broken, but log an error and continue processing in case the file has a later modified date than expected.
-                                Log.Error("Header verification failed for {FilePath}. An earlier LSN is required: {redoStartOrPreviousLastLSN}, FirstLSN: {FirstLSN}, LastLSN: {LastLSN}. NOTE: We previously found a log that was too early to apply.  Log chain might be broken, requiring manual intervention. Continuing to check log files just in case the file has a later modified date than expected.",
-                                    logBackup.FilePath, redoStartOrPreviousLastLSN, header.FirstLSN, header.LastLSN);
+
+                            case LogRestoreAction.TooOld:
+                                earlierLogFound = true;
+                                Log.Information("Skipping {logPath}.  A later LSN is required: {RequiredLSN}, FirstLSN: {FirstLSN}, LastLSN: {LastLSN}", logBackup.FilePath, redoStartOrPreviousLastLSN, header.FirstLSN, header.LastLSN);
                                 continue;
-                            }
-                            throw new HeaderVerificationException($"Header verification failed for {logBackup.FilePath}.  An earlier LSN is required: {redoStartOrPreviousLastLSN}, FirstLSN: {header.FirstLSN}, LastLSN: {header.LastLSN}", BackupHeader.HeaderVerificationStatus.TooRecent);
+
+                            case LogRestoreAction.TooRecent:
+                                if (earlierLogFound && reProcess)
+                                {
+                                    // The current log is too recent. We previously adjusted the search date looking for an earlier log.  Now we have found log files that are too early to apply, then this log that is too recent
+                                    // The log chain appears to be broken, but log an error and continue processing in case the file has a later modified date than expected.
+                                    Log.Error("Header verification failed for {FilePath}. An earlier LSN is required: {redoStartOrPreviousLastLSN}, FirstLSN: {FirstLSN}, LastLSN: {LastLSN}. NOTE: We previously found a log that was too early to apply.  Log chain might be broken, requiring manual intervention. Continuing to check log files just in case the file has a later modified date than expected.",
+                                        logBackup.FilePath, redoStartOrPreviousLastLSN, header.FirstLSN, header.LastLSN);
+                                    continue;
+                                }
+                                throw new HeaderVerificationException($"Header verification failed for {logBackup.FilePath}.  An earlier LSN is required: {redoStartOrPreviousLastLSN}, FirstLSN: {header.FirstLSN}, LastLSN: {header.LastLSN}", BackupHeader.HeaderVerificationStatus.TooRecent);
+
+                            case LogRestoreAction.Apply:
+                                Log.Information("Header verification successful for {logPath}, FILE={Position}. FirstLSN: {FirstLSN}, LastLSN: {LastLSN}", logBackup.FilePath, header.Position, header.FirstLSN, header.LastLSN);
+                                break;
+                        }
+
+                        if (breakProcessingFlag)
+                        {
+                            break; // WaitDelay - stop processing this and subsequent files
                         }
 
                         var completed = ProcessRestoreCommand(sql, targetDb, file);
@@ -498,6 +551,12 @@ namespace LogShippingService
                             break;
                         }
                         redoStartOrPreviousLastLSN = header.LastLSN;
+                        if (completed)
+                        {
+                            // Advance the reference as we restore logs in the current chain
+                            currentChainCreationDate = header.DatabaseCreationDate;
+                            currentChainBackupFinishDate = header.BackupFinishDate;
+                        }
                     }
                 }
                 else
@@ -505,8 +564,155 @@ namespace LogShippingService
                     ProcessRestoreCommand(sql, targetDb, file);
                 }
             }
+
+            if (brokenChainHeader != null)
+            {
+                var reason = brokenChainStatus == LogChainStatus.Recreated
+                    ? $"source database {sourceDb} has been re-created (dropped & re-created with the same name)"
+                    : $"the log chain for source database {sourceDb} has been broken (e.g. the recovery model was switched to SIMPLE and back to FULL)";
+                if (Config.EnableReinitialization)
+                {
+                    AuditLog.Reinitialization.Warning("The log chain for {targetDb} cannot continue - {reason}.  {logPath} begins a new log chain (BeginsLogChain: {BeginsLogChain}, DatabaseCreationDate: {DatabaseCreationDate:o}, FirstLSN: {FirstLSN}).  EnableReinitialization is enabled - {targetDb} will be dropped and re-initialized.",
+                        targetDb, reason, brokenChainLogPath, brokenChainHeader.BeginsLogChain, brokenChainHeader.DatabaseCreationDate, brokenChainHeader.FirstLSN, targetDb);
+                    throw new ReinitializeRequiredException(
+                        $"The log chain for {targetDb} cannot continue - {reason}.  {brokenChainLogPath} begins a new log chain (BeginsLogChain: {brokenChainHeader.BeginsLogChain}, DatabaseCreationDate: {brokenChainHeader.DatabaseCreationDate:o}, FirstLSN: {brokenChainHeader.FirstLSN}).  {targetDb} must be dropped and re-initialized from a current backup to resume log shipping.",
+                        sourceDb, targetDb, reason);
+                }
+                AuditLog.Reinitialization.Error("The log chain for {targetDb} cannot continue - {reason}.  {logPath} begins a new log chain (BeginsLogChain: {BeginsLogChain}, DatabaseCreationDate: {DatabaseCreationDate:o}, FirstLSN: {FirstLSN}).  {targetDb} must be dropped and re-initialized from a current backup to resume log shipping.  Set EnableReinitialization to true to perform this automatically.",
+                    targetDb, reason, brokenChainLogPath, brokenChainHeader.BeginsLogChain, brokenChainHeader.DatabaseCreationDate, brokenChainHeader.FirstLSN, targetDb);
+            }
+
             RestoreWithStandby(targetDb);
             return Task.CompletedTask;
+        }
+
+        internal enum LogChainStatus
+        {
+            /// <summary>The log continues the current chain, or its position simply doesn't line up yet (not a broken chain).</summary>
+            Ok,
+
+            /// <summary>The source database has been dropped &amp; re-created with the same name (newer DatabaseCreationDate).</summary>
+            Recreated,
+
+            /// <summary>The log chain has been reset/broken at the source (e.g. recovery model switched to SIMPLE and back to FULL).</summary>
+            Broken
+        }
+
+        /// <summary>
+        /// The action to take for a single log backup, based on its position relative to the current redo point,
+        /// the restore delay, and the chain integrity (<see cref="GetLogChainStatus"/>).  Produced by <see cref="ClassifyLog"/>
+        /// so the restore loop can switch on intent rather than re-deriving the decision from several overlapping conditions.
+        /// </summary>
+        internal enum LogRestoreAction
+        {
+            /// <summary>The next log in the current chain - restore it.</summary>
+            Apply,
+
+            /// <summary>The log is the last one restored - the current tip (its LastLSN matches the redo point) - skip / re-process.</summary>
+            LastRestored,
+
+            /// <summary>The log is entirely before the redo point - too early to apply, skip and keep looking.</summary>
+            TooOld,
+
+            /// <summary>The log begins after the redo point - a gap; too recent to apply.</summary>
+            TooRecent,
+
+            /// <summary>The log is not yet eligible for restore because of the configured restore delay - stop processing.</summary>
+            WaitDelay,
+
+            /// <summary>The source database has been dropped &amp; re-created with the same name.</summary>
+            SourceRecreated,
+
+            /// <summary>The source log chain has been reset/broken (e.g. recovery model switched to SIMPLE and back to FULL).</summary>
+            ChainBroken
+        }
+
+        /// <summary>
+        /// Classify a single log backup into the <see cref="LogRestoreAction"/> the restore loop should take.  Precedence:
+        /// (1) the restore delay (not eligible yet), then (2) the log's LSN position relative to the current redo point, with the
+        /// chain integrity (<see cref="GetLogChainStatus"/>) overriding the position when the source was re-created or the chain
+        /// was reset.  Pure and deterministic so it can be unit-tested without a SQL Server instance - all state is passed in.
+        /// A re-created source diverts every position; a broken chain only diverts the too-old / too-recent positions (matching
+        /// the original behaviour, where an exact-tip or spanning log is never treated as broken).
+        /// </summary>
+        internal static LogRestoreAction ClassifyLog(BackupHeader header, DateTime? currentChainCreationDate, DateTime referenceBackupFinishDate, BigInteger? redoStart, DateTime now, int restoreDelayMins)
+        {
+            if (restoreDelayMins > 0 && now.Subtract(header.BackupFinishDate).TotalMinutes < restoreDelayMins)
+            {
+                return LogRestoreAction.WaitDelay;
+            }
+
+            if (header.FirstLSN <= redoStart && header.LastLSN == redoStart)
+            {
+                // The last log we already restored.  Only a re-created source diverts here (an exact-tip log can't be "ahead").
+                return GetLogChainStatus(header, currentChainCreationDate, referenceBackupFinishDate, redoStart) == LogChainStatus.Recreated
+                    ? LogRestoreAction.SourceRecreated
+                    : LogRestoreAction.LastRestored;
+            }
+            if (header.FirstLSN <= redoStart && header.LastLSN > redoStart)
+            {
+                // The next log that spans the redo point - restore it.  Only a re-created source diverts here.
+                return GetLogChainStatus(header, currentChainCreationDate, referenceBackupFinishDate, redoStart) == LogChainStatus.Recreated
+                    ? LogRestoreAction.SourceRecreated
+                    : LogRestoreAction.Apply;
+            }
+            if (header.FirstLSN < redoStart)
+            {
+                return MapChainStatus(GetLogChainStatus(header, currentChainCreationDate, referenceBackupFinishDate, redoStart), LogRestoreAction.TooOld);
+            }
+            if (header.FirstLSN > redoStart)
+            {
+                return MapChainStatus(GetLogChainStatus(header, currentChainCreationDate, referenceBackupFinishDate, redoStart), LogRestoreAction.TooRecent);
+            }
+
+            // redoStart is null (no redo point yet) - the LSN comparisons above are all false; restore the log.
+            return LogRestoreAction.Apply;
+
+            static LogRestoreAction MapChainStatus(LogChainStatus status, LogRestoreAction whenOk) => status switch
+            {
+                LogChainStatus.Recreated => LogRestoreAction.SourceRecreated,
+                LogChainStatus.Broken => LogRestoreAction.ChainBroken,
+                _ => whenOk
+            };
+        }
+
+        /// <summary>
+        /// Classify a log backup that does not connect to the current redo point.  A newer DatabaseCreationDate means the source database
+        /// was re-created.  BeginsLogChain means a new log chain has started that we can't bridge onto - but only treat it as broken when it
+        /// is ahead of our redo point (FirstLSN > redo start) or we have no reference chain, otherwise it is just our own chain's original
+        /// first log re-appearing (older finish date pulled in by a reProcess walk-back) which is safe to skip.  As a safeguard for the
+        /// destructive re-initialization, a chain is only ever considered broken when the log was genuinely taken after the last log we
+        /// restored (BackupFinishDate) - protects against acting on a stale or out-of-order backup file.
+        /// </summary>
+        internal static LogChainStatus GetLogChainStatus(BackupHeader header, DateTime? currentChainCreationDate, DateTime referenceBackupFinishDate, BigInteger? redoStart)
+        {
+            if (header.BackupFinishDate <= referenceBackupFinishDate)
+            {
+                return LogChainStatus.Ok; // Not newer than the last log we restored - don't treat as a broken chain
+            }
+            if (currentChainCreationDate.HasValue && header.DatabaseCreationDate > currentChainCreationDate.Value)
+            {
+                return LogChainStatus.Recreated;
+            }
+            if (header.BeginsLogChain && (redoStart == null || header.FirstLSN > redoStart || !currentChainCreationDate.HasValue))
+            {
+                return LogChainStatus.Broken;
+            }
+            return LogChainStatus.Ok;
+        }
+
+        private static void LogBrokenChainDetected(LogChainStatus status, string sourceDb, string logPath, BackupHeader header, DateTime? currentChainCreationDate, BigInteger? redoStart)
+        {
+            if (status == LogChainStatus.Recreated)
+            {
+                Log.Warning("Detected that source database {sourceDb} has been re-created (dropped & re-created with the same name).  {logPath} belongs to a newer incarnation - DatabaseCreationDate: {HeaderCreateDate} is newer than the current chain: {ChainCreateDate}.  BeginsLogChain: {BeginsLogChain}, FirstLSN: {FirstLSN}, LastLSN: {LastLSN}",
+                    sourceDb, logPath, header.DatabaseCreationDate, currentChainCreationDate, header.BeginsLogChain, header.FirstLSN, header.LastLSN);
+            }
+            else
+            {
+                Log.Warning("Detected a broken log chain for source database {sourceDb} (e.g. the recovery model was switched to SIMPLE and back to FULL).  {logPath} begins a new log chain that cannot be applied - BeginsLogChain: {BeginsLogChain}, FirstLSN: {FirstLSN}, LastLSN: {LastLSN}, required LSN: {RequiredLSN}",
+                    sourceDb, logPath, header.BeginsLogChain, header.FirstLSN, header.LastLSN, redoStart);
+            }
         }
 
         private static bool ProcessRestoreCommand(string sql, string db, string file)
@@ -552,7 +758,7 @@ namespace LogShippingService
             return false;
         }
 
-        private static bool KillUserConnections(string db)
+        internal static bool KillUserConnections(string db)
         {
             if (Config.KillUserConnections)
             {

--- a/sql-log-shipping-service/Program.cs
+++ b/sql-log-shipping-service/Program.cs
@@ -2,6 +2,7 @@
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Serilog;
+using Serilog.Filters;
 
 namespace LogShippingService
 {
@@ -59,14 +60,15 @@ namespace LogShippingService
             if (configuration != null && serilogSection.Exists() && serilogSection.GetChildren().Any())
             {
                 // Configure Serilog from the configuration file
-                Log.Logger = new LoggerConfiguration()
-                    .ReadFrom.Configuration(configuration)
-                    .CreateLogger();
+                var loggerConfiguration = new LoggerConfiguration()
+                    .ReadFrom.Configuration(configuration);
+                AddReinitializationLog(loggerConfiguration);
+                Log.Logger = loggerConfiguration.CreateLogger();
             }
             else
             {
                 // Configure Serilog with default settings programmatically
-                Log.Logger = new LoggerConfiguration()
+                var loggerConfiguration = new LoggerConfiguration()
                     .MinimumLevel.Debug()
                     .WriteTo.Console(outputTemplate: "{Timestamp:yyyy-MM-dd HH:mm:ss.fff zzz} [{Level:u3}] {Message:lj} <{ThreadId}>{NewLine}{Exception}")
                     .WriteTo.File(path: "Logs/log-.txt",
@@ -76,9 +78,24 @@ namespace LogShippingService
                     .Enrich.FromLogContext()
                     .Enrich.WithMachineName()
                     .Enrich.WithThreadId()
-                    .Enrich.WithProperty("Application", "LogShippingService")
-                    .CreateLogger();
+                    .Enrich.WithProperty("Application", "LogShippingService");
+                AddReinitializationLog(loggerConfiguration);
+                Log.Logger = loggerConfiguration.CreateLogger();
             }
+        }
+
+        /// <summary>
+        /// Write database re-initialization events (tagged via <see cref="AuditLog.ReinitializationProperty"/>) to a dedicated log
+        /// file, in addition to the main log.  These events are rare but significant (a database is dropped &amp; rebuilt) so a
+        /// separate, easy to find record is kept.
+        /// </summary>
+        private static void AddReinitializationLog(LoggerConfiguration loggerConfiguration)
+        {
+            loggerConfiguration.WriteTo.Logger(reinitLog => reinitLog
+                .Filter.ByIncludingOnly(Matching.WithProperty<bool>(AuditLog.ReinitializationProperty, isReinit => isReinit))
+                .WriteTo.File(path: "Logs/reinitialization-.txt",
+                    rollingInterval: RollingInterval.Month,
+                    outputTemplate: "{Timestamp:yyyy-MM-dd HH:mm:ss.fff zzz} [{Level:u3}] {Message:lj} <{ThreadId}>{NewLine}{Exception}"));
         }
     }
 }

--- a/sql-log-shipping-service/ReinitializeRequiredException.cs
+++ b/sql-log-shipping-service/ReinitializeRequiredException.cs
@@ -1,0 +1,25 @@
+namespace LogShippingService
+{
+    /// <summary>
+    /// Thrown when a log backup is found that cannot be applied because the source log chain has been reset.
+    /// This happens when the source database is dropped and re-created with the same name, or when the log chain
+    /// is otherwise broken (e.g. the recovery model is switched to SIMPLE and back to FULL).
+    /// The log-shipped database must be dropped and re-initialized from a current backup to resume log shipping.
+    /// </summary>
+    public class ReinitializeRequiredException : Exception
+    {
+        public string SourceDb { get; }
+        public string TargetDb { get; }
+
+        /// <summary>Human readable description of why the log chain can't be continued - the source database was re-created, or the log chain was otherwise broken.</summary>
+        public string Reason { get; }
+
+        public ReinitializeRequiredException(string message, string sourceDb, string targetDb, string reason)
+            : base(message)
+        {
+            SourceDb = sourceDb;
+            TargetDb = targetDb;
+            Reason = reason;
+        }
+    }
+}

--- a/test/CI_Workflow-NoReinit.Tests.ps1
+++ b/test/CI_Workflow-NoReinit.Tests.ps1
@@ -1,0 +1,50 @@
+Describe 'CI Workflow checks - No Re-initialize (safety)' {
+
+	BeforeAll {
+		function Get-FullRestoreCount($db) {
+			(Invoke-DbaQuery -SqlInstance "LOCALHOST" -As PSObject -Query "SELECT COUNT(*) AS FullRestores
+				FROM msdb.dbo.restorehistory
+				WHERE destination_database_name = '$db'
+				AND restore_type = 'D';").FullRestores
+		}
+		function Get-Marker($db) {
+			(Invoke-DbaQuery -SqlInstance "LOCALHOST" -As PSObject -Database $db -Query "SELECT MAX(Id) AS Id FROM dbo.Marker").Id
+		}
+		$script:ReinitLog = @(@(Get-ChildItem -Path "C:\sql-log-shipping-service\Logs\reinitialization-*.txt" -ErrorAction SilentlyContinue) | Get-Content)
+	}
+
+	It 'Copies are still in standby' {
+		@(Get-DbaDatabase -SqlInstance "LOCALHOST" -Status "Standby" -Database "ReInit1_Copy","ReInit2_Copy").Count | Should -Be 2
+	}
+
+	Context 'ReInit1 - source re-created but re-initialization disabled' {
+		It 'Copy still reflects the original incarnation (marker = 1)' {
+			Get-Marker 'ReInit1_Copy' | Should -Be 1
+		}
+		It 'Copy was NOT re-initialized (restored from FULL only once)' {
+			Get-FullRestoreCount 'ReInit1_Copy' | Should -Be 1
+		}
+	}
+
+	Context 'ReInit2 - broken log chain but re-initialization disabled' {
+		It 'Copy still reflects the original chain (marker = 1)' {
+			Get-Marker 'ReInit2_Copy' | Should -Be 1
+		}
+		It 'Copy was NOT re-initialized (restored from FULL only once)' {
+			Get-FullRestoreCount 'ReInit2_Copy' | Should -Be 1
+		}
+	}
+
+	It 'The audit log warns that re-initialization is required but disabled' {
+		# With EnableReinitialization disabled the service still detects the broken chains and logs that
+		# re-initialization is required (mentioning EnableReinitialization) - this is expected and desirable.
+		($script:ReinitLog -match 'Set EnableReinitialization to true').Count | Should -BeGreaterThan 0
+	}
+
+	It 'No database was actually dropped or re-initialized' {
+		# The destructive actions must NOT have run.  Only match audit phrases that are written when a drop /
+		# re-initialization actually executes - NOT the "must be dropped and re-initialized" advisory that the
+		# disabled path logs (which merely tells the operator what would be required).
+		($script:ReinitLog -match 'Dropping .* so it can be re-initialized|has been dropped and re-initialized from a current backup').Count | Should -Be 0
+	}
+}

--- a/test/CI_Workflow-Reinitialize.Tests.ps1
+++ b/test/CI_Workflow-Reinitialize.Tests.ps1
@@ -1,0 +1,56 @@
+Describe 'CI Workflow checks - Re-initialize' {
+
+    BeforeAll {
+        function Get-FullRestoreCount($db) {
+            (Invoke-DbaQuery -SqlInstance "LOCALHOST" -As PSObject -Query "SELECT COUNT(*) AS FullRestores
+                FROM msdb.dbo.restorehistory
+                WHERE destination_database_name = '$db'
+                AND restore_type = 'D';").FullRestores
+        }
+        function Get-Marker($db) {
+            (Invoke-DbaQuery -SqlInstance "LOCALHOST" -As PSObject -Database $db -Query "SELECT MAX(Id) AS Id FROM dbo.Marker").Id
+        }
+        $script:ReinitLog = @(@(Get-ChildItem -Path "C:\sql-log-shipping-service\Logs\reinitialization-*.txt" -ErrorAction SilentlyContinue) | Get-Content)
+    }
+
+    It 'All copies are in standby' {
+        @(Get-DbaDatabase -SqlInstance "LOCALHOST" -Status "Standby" -Database "ReInit1_Copy","ReInit2_Copy","ReInit3_Copy").Count | Should -Be 3
+    }
+
+    Context 'ReInit1 - source database re-created' {
+        It 'Copy reflects the new incarnation (marker = 2)' {
+            Get-Marker 'ReInit1_Copy' | Should -Be 2
+        }
+        It 'Copy was re-initialized exactly once (restored from FULL exactly twice)' {
+            Get-FullRestoreCount 'ReInit1_Copy' | Should -Be 2
+        }
+        It 'Re-initialization was recorded in the audit log' {
+            ($script:ReinitLog -match 'ReInit1_Copy').Count | Should -BeGreaterThan 0
+        }
+    }
+
+    Context 'ReInit2 - recovery model switched to SIMPLE and back to FULL' {
+        It 'Copy reflects the data after the broken chain (marker = 2)' {
+            Get-Marker 'ReInit2_Copy' | Should -Be 2
+        }
+        It 'Copy was re-initialized exactly once (restored from FULL exactly twice)' {
+            Get-FullRestoreCount 'ReInit2_Copy' | Should -Be 2
+        }
+        It 'Re-initialization was recorded in the audit log' {
+            ($script:ReinitLog -match 'ReInit2_Copy').Count | Should -BeGreaterThan 0
+        }
+    }
+
+    Context 'ReInit3 - normal continuation (must NOT be re-initialized)' {
+        It 'Copy received the new data via normal log restore (marker = 2)' {
+            Get-Marker 'ReInit3_Copy' | Should -Be 2
+        }
+        It 'Copy was NOT re-initialized (restored from FULL only once)' {
+            Get-FullRestoreCount 'ReInit3_Copy' | Should -Be 1
+        }
+        It 'Copy does not appear in the re-initialization audit log' {
+            ($script:ReinitLog -match 'ReInit3_Copy').Count | Should -Be 0
+        }
+    }
+
+}


### PR DESCRIPTION
Added EnableReinitialization to automatically re-initialize databases when we detect a broken log chain. e.g.
Database is re-created.
Recovery model was changed to SIMPLE and back to FULL.

Default to better logging with option to drop & re-initialize.

Code refactoring and workflow improvements.